### PR TITLE
Mapping demo with vector matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.bak #for spell checking
+
+.ipynb_checkpoints/

--- a/SED Phase & Orientation Mapping - Intermediate.ipynb
+++ b/SED Phase & Orientation Mapping - Intermediate.ipynb
@@ -29,6 +29,8 @@
     "import diffpy.structure\n",
     "from matplotlib import pyplot as plt\n",
     "from pyxem.generators.indexation_generator import IndexationGenerator\n",
+    "from pyxem.generators.library_generator import VectorLibraryGenerator\n",
+    "from pyxem.generators.indexation_generator import VectorIndexationGenerator\n",
     "from pyxem.generators.structure_library_generator import StructureLibraryGenerator\n",
     "from pyxem.utils.sim_utils import peaks_from_best_template\n",
     "from pyxem.utils.plot import generate_marker_inputs_from_peaks\n",
@@ -88,14 +90,15 @@
     "half_pattern_size = pattern_size // 2\n",
     "reciprocal_radius = 1.2\n",
     "calibration = reciprocal_radius / half_pattern_size\n",
-    "ediff = pxm.DiffractionGenerator(300.0, 0.025)  # keV and relrod length (1/Å)"
+    "beam_energy = 300.0\n",
+    "ediff = pxm.DiffractionGenerator(beam_energy, 0.025)  # keV and relrod length (1/Å)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now create 4 seperate patterns, 2 for each crystal, one at 0 degress and one at 10 degrees, but this is all very artificial"
+    "We now create 4 seperate patterns, 2 for each crystal, one at 0 degress and one at 10 degrees, but this is all very artificial."
    ]
   },
   {
@@ -104,7 +107,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_lib = StructureLibrary(['Si', 'Ga'], [si, ga], [\n",
+    "phase_names = ['Si', 'Ga'] \n",
+    "sample_lib = StructureLibrary(phase_names, [si, ga], [\n",
     "                                  [(10,0,0), (0,0,0)],  # For Si\n",
     "                                  [(0,0,0), (10,0,0)]   # For Ga\n",
     "                              ])\n",
@@ -153,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<center><h2> Doing the mapping </h2></center>"
+    "<center><h2> Mapping with template matching </h2></center>"
    ]
   },
   {
@@ -212,7 +216,6 @@
    "outputs": [],
    "source": [
     "indexer = IndexationGenerator(test_data, template_library)\n",
-    "phase_names = ['Si', 'Ga'] \n",
     "match_results = indexer.correlate(n_largest=1, keys=phase_names)"
    ]
   },
@@ -229,12 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "peaks = match_results.map(peaks_from_best_template, phase=phase_names, library=template_library, inplace=False, parallel=False)\n",
-    "mmx, mmy = generate_marker_inputs_from_peaks(peaks)\n",
-    "test_data.plot(cmap='viridis') \n",
-    "for mx, my in zip(mmx, mmy):\n",
-    "    m = hs.markers.point(x=mx, y=my, color='red', marker='x')\n",
-    "    test_data.add_marker(m, plot_marker=True, permanent=True)"
+    "match_results.plot_best_matching_results_on_signal(test_data, phase_names, template_library, permanent_markers=False)"
    ]
   },
   {
@@ -242,6 +240,137 @@
    "metadata": {},
    "source": [
     "Remeber our rotations are anti-clockwise!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<center><h2> Mapping with vector matching </h2></center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Vector matching starts with finding the diffraction spots using peak finding. The cross correlation `'xc'` method (which works by comparison to an example peak) works good on this example. Using the camera length, we calculate the 3D $\\vec g$ that are used for the matching."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "peak_example = test_data.inav[0, 0].isig[122:135, 101:114].data\n",
+    "peaks = test_data.find_peaks('xc', disc_image=peak_example, peak_threshold=0.8)\n",
+    "peaks.calculate_cartesian_coordinates(beam_energy, 0.2)  # Camera length in meters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can explore other peak finding methods using the interactive viewer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#test_data.find_peaks_interactive(peak_example)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we create the vector library which contain peak pairs that are matched against the experimental peaks. No rotation list is required for the structure library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structure_library = StructureLibrary(['Si', 'Ga'], [si, ga], [[], []])\n",
+    "library_generator = VectorLibraryGenerator(structure_library)\n",
+    "vector_library = library_generator.get_vector_library(reciprocal_radius)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, run the indexing. We look for peak pairs with vector lengths within 1.5 pixels and angle within 1° of the experimental peaks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indexation_generator = VectorIndexationGenerator(peaks, vector_library)\n",
+    "indexation = indexation_generator.index_vectors(mag_tol=1.5*calibration,\n",
+    "                                                angle_tol=1,\n",
+    "                                                index_error_tol=0.2,\n",
+    "                                                n_peaks_to_index=5,\n",
+    "                                                n_best=2,\n",
+    "                                                keys=['Si', 'Ga'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From the indexed peaks, we can calculate the crystallographic map for easier access to the indexing results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cryst_map = indexation.get_crystallographic_map()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can, for example, plot the match rate which indicates how successfull the mapping was."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cryst_map.get_metric_map('match_rate').plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or we can plot the peaks on top of the diffraction patterns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indexation.plot_best_matching_results_on_signal(test_data, phase_names,\n",
+    "                                                vector_library, ediff, reciprocal_radius,\n",
+    "                                                permanent_markers=False)"
    ]
   },
   {

--- a/SED Phase & Orientation Mapping - Intermediate.ipynb
+++ b/SED Phase & Orientation Mapping - Intermediate.ipynb
@@ -29,6 +29,7 @@
     "import diffpy.structure\n",
     "from matplotlib import pyplot as plt\n",
     "from pyxem.generators.indexation_generator import IndexationGenerator\n",
+    "from pyxem.generators.structure_library_generator import StructureLibraryGenerator\n",
     "from pyxem.utils.sim_utils import peaks_from_best_template\n",
     "from pyxem.utils.plot import generate_marker_inputs_from_peaks\n",
     "from pyxem.libraries.structure_library import StructureLibrary"
@@ -83,9 +84,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "size = 256 #pattern size in pixels\n",
-    "radius=1.2 #reciprocal radius\n",
-    "ediff = pxm.DiffractionGenerator(300., 0.025) #eV and relrod size"
+    "pattern_size = 256  # pixels\n",
+    "half_pattern_size = pattern_size // 2\n",
+    "reciprocal_radius = 1.2\n",
+    "calibration = reciprocal_radius / half_pattern_size\n",
+    "ediff = pxm.DiffractionGenerator(300.0, 0.025)  # keV and relrod length (1/Å)"
    ]
   },
   {
@@ -101,29 +104,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_lib = StructureLibrary(['si','ga'],[si,ga],[[(10,0,0),(0,0,0)],[(0,0,0),(10,0,0)]])\n",
-    "sample_lib.struct_lib\n",
+    "sample_lib = StructureLibrary(['Si', 'Ga'], [si, ga], [\n",
+    "                                  [(10,0,0), (0,0,0)],  # For Si\n",
+    "                                  [(0,0,0), (10,0,0)]   # For Ga\n",
+    "                              ])\n",
     "\n",
     "diff_gen = pxm.DiffractionLibraryGenerator(ediff)\n",
     "library = diff_gen.get_diffraction_library(sample_lib,\n",
-    "                                           calibration=1 / 64,\n",
-    "                                           reciprocal_radius=0.8,\n",
-    "                                           half_shape=(64,64),\n",
+    "                                           calibration=calibration,\n",
+    "                                           reciprocal_radius=reciprocal_radius,\n",
+    "                                           half_shape=(half_pattern_size, half_pattern_size),\n",
     "                                           with_direct_beam=False)\n",
     "\n",
     "data_silicon = []\n",
     "data_gallium = []\n",
     "\n",
-    "for theta in [0,10]:\n",
-    "    _ = library.get_library_entry(phase='si',angle=(theta,0,0))['Sim'].as_signal(128,0.03,1)\n",
-    "    data_silicon.append(_)\n",
-    "    _ = library.get_library_entry(phase='ga',angle=(theta,0,0))['Sim'].as_signal(128,0.03,1)\n",
-    "    data_gallium.append(_)\n",
+    "for theta in [0, 10]:\n",
+    "    pattern = library.get_library_entry(\n",
+    "        phase='Si', angle=(theta, 0, 0))['Sim'].as_signal(pattern_size, 0.03, reciprocal_radius)\n",
+    "    data_silicon.append(pattern)\n",
+    "    pattern = library.get_library_entry(\n",
+    "        phase='Ga', angle=(theta, 0, 0))['Sim'].as_signal(pattern_size, 0.03, reciprocal_radius)\n",
+    "    data_gallium.append(pattern)\n",
     "        \n",
     "data = [x.data for x in data_silicon] + [x.data for x in data_gallium]\n",
     "\n",
-    "test_data = pxm.ElectronDiffraction(np.asarray(data).reshape(2,2,128,128))\n",
-    "test_data.set_diffraction_calibration(1/64)"
+    "test_data = pxm.ElectronDiffraction(np.asarray(data).reshape(2, 2, pattern_size, pattern_size))\n",
+    "test_data.set_diffraction_calibration(calibration) "
    ]
   },
   {
@@ -139,7 +146,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "test_data now contains the 4 patterns we will attempt to match to, we move onto creating a library"
+    "`test_data` now contains the 4 patterns we will attempt to match to, representing our experimental diffraction patterns. We move onto creating a library."
    ]
   },
   {
@@ -153,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First we need to create a list of potential rotations"
+    "First we need to create a structure library (see the docstrings for details). The structure library generator has an utility function for creating a library covering all unique rotations for the specified structures."
    ]
   },
   {
@@ -162,32 +169,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rot_list = []\n",
-    "for theta in np.linspace(0,15,50): \n",
-    "    rot_list.append((theta, 0, 0.))    #needs to be a tuple"
+    "structure_library_generator = StructureLibraryGenerator(\n",
+    "    [('Si', si, 'cubic'),\n",
+    "     ('Ga', ga, 'hexagonal')])\n",
+    "structure_library = structure_library_generator.get_orientations_from_stereographic_triangle(\n",
+    "    [(0, 10), (0, 10)],  # Inplane rotations to include\n",
+    "    5)  # Angular resolution of the library"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And then a structure library (see the docstrings for details)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "search_lib = StructureLibrary(['si','ga'],[si,ga],[rot_list,rot_list])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The next step generates a library, which contains simulated diffraction data"
+    "The next step generates a library of simulated diffraction data"
    ]
   },
   {
@@ -197,18 +191,18 @@
    "outputs": [],
    "source": [
     "diff_gen = pxm.DiffractionLibraryGenerator(ediff)\n",
-    "library = diff_gen.get_diffraction_library(search_lib,\n",
-    "                                            calibration=1/64,\n",
-    "                                            reciprocal_radius=0.7,\n",
-    "                                            half_shape=(64,64),\n",
-    "                                            with_direct_beam=True)"
+    "template_library = diff_gen.get_diffraction_library(structure_library,\n",
+    "                                                    calibration=calibration,\n",
+    "                                                    reciprocal_radius=reciprocal_radius-0.1,\n",
+    "                                                    half_shape=(half_pattern_size, half_pattern_size),\n",
+    "                                                    with_direct_beam=False)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "which we then correlate with the test (normally experimental) dataset"
+    "which we then correlate with the test (normally experimental) dataset."
    ]
   },
   {
@@ -217,16 +211,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "indexer = IndexationGenerator(test_data, library)\n",
-    "phase=[\"si\",\"ga\"] \n",
-    "match_results = indexer.correlate(n_largest=2,keys=phase)"
+    "indexer = IndexationGenerator(test_data, template_library)\n",
+    "phase_names = ['Si', 'Ga'] \n",
+    "match_results = indexer.correlate(n_largest=1, keys=phase_names)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "we then have a range of ways of working with this output, but here we simply plot it to show that the method has worked as anticipated"
+    "We now have a range of ways of working with this output, but here we simply plot it to show that the method has worked as anticipated."
    ]
   },
   {
@@ -235,12 +229,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "peaks= match_results.map(peaks_from_best_template,phase=phase,library=library,inplace=False)\n",
-    "mmx,mmy = generate_marker_inputs_from_peaks(peaks)\n",
+    "peaks = match_results.map(peaks_from_best_template, phase=phase_names, library=template_library, inplace=False, parallel=False)\n",
+    "mmx, mmy = generate_marker_inputs_from_peaks(peaks)\n",
     "test_data.plot(cmap='viridis') \n",
-    "for mx,my in zip(mmx,mmy):\n",
-    "    m = hs.markers.point(x=mx,y=my,color='red',marker='x')\n",
-    "    test_data.add_marker(m,plot_marker=True,permanent=True)"
+    "for mx, my in zip(mmx, mmy):\n",
+    "    m = hs.markers.point(x=mx, y=my, color='red', marker='x')\n",
+    "    test_data.add_marker(m, plot_marker=True, permanent=True)"
    ]
   },
   {
@@ -261,7 +255,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is playground to help you get used to our rotation convention. \"f1\" and \"f2\" will be plotted as figure 1 and 2 respectively (assuming no figures are open when you run the cell) - and each is set to an euler triplet"
+    "Below is playground to help you get used to our rotation convention. \"f1\" and \"f2\" will be plotted as in windows with the corresponding name - and each is set to an euler triplet."
    ]
   },
   {
@@ -270,9 +264,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f1 = (90,-3,-90)\n",
-    "f2 = (90,+3,-90)\n",
-    "sample_lib = StructureLibrary(['si'],[si],[[f1,f2]])\n",
+    "f1 = (90, -3, -90)\n",
+    "f2 = (90, +3, -90)\n",
+    "sample_lib = StructureLibrary(['Si'], [si], [[f1, f2]])\n",
     "diff_gen = pxm.DiffractionLibraryGenerator(ediff)\n",
     "library = diff_gen.get_diffraction_library(sample_lib,\n",
     "                                           calibration=1 / 64,\n",
@@ -280,13 +274,13 @@
     "                                           half_shape=(64,64),\n",
     "                                           with_direct_beam=False)\n",
     "\n",
-    "_ = library.get_library_entry(phase='si',angle=f1)['Sim'].as_signal(128,0.03,1)\n",
-    "plt.figure()\n",
-    "plt.imshow(_,cmap='viridis',vmax=0.1)\n",
+    "pattern = library.get_library_entry(phase='Si', angle=f1)['Sim'].as_signal(pattern_size, 0.03, 1)\n",
+    "plt.figure('f1')\n",
+    "plt.imshow(pattern, cmap='viridis', vmax=0.1)\n",
     "\n",
-    "_ = library.get_library_entry(phase='si',angle=f2)['Sim'].as_signal(128,0.03,1)\n",
-    "plt.figure()\n",
-    "plt.imshow(_,cmap='viridis',vmax=0.1)"
+    "pattern = library.get_library_entry(phase='Si', angle=f2)['Sim'].as_signal(pattern_size, 0.03, 1)\n",
+    "plt.figure('f2')\n",
+    "plt.imshow(pattern, cmap='viridis', vmax=0.1)"
    ]
   }
  ],
@@ -307,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/SED Phase & Orientation Mapping - Intermediate.ipynb
+++ b/SED Phase & Orientation Mapping - Intermediate.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2><center> Creating a \"fake\" dataset </h2></center>"
+    "<center><h2>Creating a \"fake\" dataset</h2></center>"
    ]
   },
   {


### PR DESCRIPTION
Add a vector matching demo to the phase and orientation mapping notebook, including peak finding, indexing and displaying results. The commit also contains some code-style cleanup in the rest of the notebook.

This PR depends on https://github.com/pyxem/pyxem/pull/343.