### PR TITLE
Fix phase & orientation map variable name

### DIFF
--- a/Phase & Orientation Mapping.ipynb
+++ b/Phase & Orientation Mapping.ipynb
@@ -432,7 +432,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cryst_map = match_results.get_crystallographic_map()\n",
+    "cryst_map = indexation.get_crystallographic_map()\n",
     "ori_map = cryst_map.get_orientation_map()\n",
     "ori_map.plot(cmap='inferno')"
    ]


### PR DESCRIPTION
The vector matching section used the match results from the template matching section when creating the crystal map.