### PR TITLE
Updating Strain Mapping for 0.7.1

### DIFF
--- a/Strain Mapping.ipynb
+++ b/Strain Mapping.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All functionality has been checked to run using pyxem-0.7"
+    "All functionality has been checked to run using pyxem-0.7.1"
    ]
   },
   {
@@ -387,13 +387,6 @@
    "source": [
     "strain_map.plot(cmap='seismic',vmax=0.04,vmin=-0.04)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -413,7 +406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.7"
   },
   "widgets": {
    "state": {


### PR DESCRIPTION
Everything still works. Having checked that (and after this is merged) we can probably tag the repo for a release of pyxem-demos.