### PR TITLE
Nanocrystal segmentation in SPED data

### DIFF
--- a/06 Nanocrystal segmentation in SPED data - Demonstration on partly overlapping MgO cubes.ipynb
+++ b/06 Nanocrystal segmentation in SPED data - Demonstration on partly overlapping MgO cubes.ipynb
@@ -1,0 +1,1714 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 06 Nanocrystal segmentation in scanning precession electron diffraction data - Full demonstration on partly overlapping MgO cubes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates two approaches to nanocrystal segmentation:\n",
+    "1. Virtual dark-field (VDF) imaging-based segmentation\n",
+    "2. Non-negative matrix factorisation (NMF)-based segmentation\n",
+    "\n",
+    "The segmentation is demonstrated on a SPED dataset of partly overlapping MgO nanoparticles, where some of the particles share the same orientation. The SPED data can be found in [1]. An article including explanation of the methods and discussions of the results is under review. \n",
+    "\n",
+    "[1] T Bergh. (2019) *Scanning precession electron diffraction data of partly overlapping magnesium oxide nanoparticles.* doi: 10.5281/zenodo.3382874."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib qt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import hyperspy.api as hs\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pyxem as pxm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load and pre-process data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and bin data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the binned data, or alternatively load the full data and bin it in navigation space:\n",
+    "\n",
+    "`s = hs.load('SPED_data_of_MgO_nanoparticles.hdf5')\n",
+    "s = s.rebin(scale=(2,2,1,1))\n",
+    "s = pxm.ElectronDiffraction2D(s)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = pxm.load_hspy('MgO2_16_TX5_c_bin2,2.hdf5',\n",
+    "                  lazy=False, \n",
+    "                  assign_to='electron_diffraction2d')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Inspect the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s.plot(cmap='magma_r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Align the direct beam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TODO : Add option for square_width in the get_direct_beam_position function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_center_beam_position(self, radius_start, radius_finish,\n",
+    "                             square_width=None, *args, **kwargs):\n",
+    "    \"\"\"Estimate the direct beam position in each experimentally acquired\n",
+    "    electron diffraction pattern.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    radius_start : int\n",
+    "        The lower bound for the radius of the central disc to be used in the\n",
+    "        alignment.\n",
+    "    radius_finish : int\n",
+    "        The upper bounds for the radius of the central disc to be used in\n",
+    "        the alignment.\n",
+    "    square_width  : int\n",
+    "        Half the side length of square that captures the direct beam in all\n",
+    "        scans. Means that the centering algorithm is stable against\n",
+    "        diffracted spots brighter than the direct beam.\n",
+    "    *args:\n",
+    "        Arguments to be passed to align2D().\n",
+    "    **kwargs:\n",
+    "        Keyword arguments to be passed to align2D().\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    shifts : np.ndarray\n",
+    "        The positions of the centre of the direct beam.\n",
+    "\n",
+    "    \"\"\"\n",
+    "    nav_shape_x = self.data.shape[0]\n",
+    "    nav_shape_y = self.data.shape[1]\n",
+    "    origin_coordinates = np.array((self.data.shape[2] / 2 - 0.5,\n",
+    "                                   self.data.shape[3] / 2 - 0.5))\n",
+    "\n",
+    "    if square_width is not None:\n",
+    "        min_index = np.int(origin_coordinates[0] - (0.5 + square_width))\n",
+    "        # fails if non-square dp\n",
+    "        max_index = np.int(origin_coordinates[0] + (1.5 + square_width))\n",
+    "        shifts = self.isig[min_index:max_index, min_index:max_index].get_direct_beam_position(\n",
+    "            radius_start=radius_start, radius_finish=radius_finish, *args, **kwargs)\n",
+    "    else:\n",
+    "        shifts = self.get_direct_beam_position(\n",
+    "            radius_start=radius_start, radius_finish=radius_finish, *args, **kwargs)\n",
+    "\n",
+    "    shifts = -1 * shifts.data\n",
+    "    shifts = shifts.reshape(nav_shape_x * nav_shape_y, 2)\n",
+    "\n",
+    "    return shifts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Find the direct beam positions. \n",
+    "\n",
+    "It is easier to find the centre positions on a dataset where the background is removed, so we do that, and then apply the found shifts to the unprocessed dataset. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9a981625f969481991c572d010cf790e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3f3de490c4b8494f90745625de0e6fe5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sigma_min = 1.7\n",
+    "sigma_max = 13.2\n",
+    "\n",
+    "shifts = get_center_beam_position(\n",
+    "    s.remove_background('gaussian_difference', \n",
+    "                        sigma_min=sigma_min, \n",
+    "                        sigma_max=sigma_max),\n",
+    "    radius_start=2, radius_finish=6, square_width=15)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualise the direct beam positions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x1c61e5c8a90>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "plt.figure()\n",
+    "plt.imshow(shifts.reshape(s.data.shape[0],s.data.shape[1],2)[..., 0])\n",
+    "plt.figure()\n",
+    "plt.imshow(shifts.reshape(s.data.shape[0],s.data.shape[1],2)[..., 1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Align the centre of the direct beam so that it is found at the same positional coordinate in all PED patterns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "639515128dc540e0a429b36316276fe6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "s.align2D(shifts=shifts, fill_value=0, crop=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set calibrations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scale = 0.03246\n",
+    "scale_real = 2.56\n",
+    "s.set_diffraction_calibration(scale)\n",
+    "s.set_scan_calibration(scale_real)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1 Virtual dark field imaging-based segmentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1(a) Pre-processing for VDF imaging-based segmentation\n",
+    "Continue with pre-processing that is only needed for the VDF imaging-based segmentation approach."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Remove the background"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1171848256f443748ceff81f9c9af001",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sigma_min = 1.7\n",
+    "sigma_max = 13.2\n",
+    "\n",
+    "s_rb = s.remove_background('gaussian_difference',\n",
+    "                           sigma_min=sigma_min,\n",
+    "                           sigma_max=sigma_max)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_rb.set_diffraction_calibration(scale)\n",
+    "s_rb.set_scan_calibration(scale_real)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Peak finding\n",
+    "Find all diffraction peaks for all PED patterns. \n",
+    "The used parameters were found by interactive peak finding:\n",
+    "\n",
+    "`peaks = s_rb.find_peaks_interactive(imshow_kwargs={'cmap': 'magma_r'})`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9967fbe77f7144038e780c605af86aa9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:hyperspy.signal:The function you applied does not take into account the difference of units and of scales in-between axes.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3d680341bf2542c28cd9ec0d64177245",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "peaks = s_rb.find_peaks(method='laplacian_of_gaussians', \n",
+    "                        min_sigma=0.7,\n",
+    "                        max_sigma=10,\n",
+    "                        num_sigma=30, \n",
+    "                        threshold=0.046, \n",
+    "                        overlap=0.5, \n",
+    "                        log_scale=False,\n",
+    "                        exclude_border=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualise the number of diffraction peaks found pr. probe position"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:hyperspy.signal:The function you applied does not take into account the difference of units and of scales in-between axes.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "20008de305d24530bdc4f49298d0b527",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "diff_map = peaks.get_diffracting_pixels_map()\n",
+    "diff_map.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Refine the peak positions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyxem.generators.subpixelrefinement_generator import SubpixelrefinementGenerator\n",
+    "from pyxem.signals.diffraction_vectors import DiffractionVectors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we have peaks at the edges of the patterns, we zero-pad the signal, to avoid errors during the refinement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_padded = np.zeros((s.data.shape[0],s.data.shape[1],\n",
+    "                     s.data.shape[2]+12,s.data.shape[2]+12))\n",
+    "s_padded[:,:,6:s.data.shape[2]+6,6:s.data.shape[2]+6] = s_rb.data\n",
+    "s_padded = pxm.ElectronDiffraction2D(s_padded)\n",
+    "s_padded.set_diffraction_calibration(scale)\n",
+    "s_padded.set_scan_calibration(scale_real)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TODO : Integrate a solution to this in pyxem?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:hyperspy.signal:The function you applied does not take into account the difference of units and of scales in-between axes.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4a4601a535054aeca27d6c79219b6cbc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c948e48d6916480aad9a3cb5c2c23be2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=12426), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "refine_gen = SubpixelrefinementGenerator(s_padded, peaks)\n",
+    "peaks_refined = DiffractionVectors(\n",
+    "    refine_gen.center_of_mass_method(square_size=4))\n",
+    "peaks_refined.axes_manager.set_signal_dimension(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_padded = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Find the unique diffraction peaks by clustering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "57  unique vectors were found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "distance_threshold = scale*0.89\n",
+    "min_samples = 10\n",
+    "\n",
+    "unique_peaks = peaks_refined.get_unique_vectors(method='DBSCAN',\n",
+    "    distance_threshold=distance_threshold, min_samples=min_samples)\n",
+    "print(np.shape(unique_peaks.data)[0], ' unique vectors were found.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualise the detected unique peaks by plotting them on the maximum of the signal. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radius_px = s_rb.axes_manager.signal_shape[0]/2\n",
+    "reciprocal_radius = radius_px * scale"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAecAAAHVCAYAAADLvzPyAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsnXmAFNW1/7/VPSvDLqCicUPzS6JBRHFHQMCgBpdoXHHXEBM0xmxGuq3p14363st7QeO+m2gWY0TFhYjsKu4KmvWZGJO4C7LPTM9U1++Pnul7Cuo45051T0/PnM8/FNW3bt1a79T3nvs9ju/7PhRFURRF6THEyt0ARVEURVGCaOesKIqiKD0M7ZwVRVEUpYehnbOiKIqi9DC0c1YURVGUHoZ2zoqiKIrSw9DOWVEURVF6GNo5K4qiKEoPQztnRVEURelhaOesKIqiKD0M7ZwVRVEUpYehnbOiKIqi9DCqyt2AruJ9+NvOC+VyZtkny06R/iaJkXok+5K0gZah0PLcfm3aFRdceq8tvDxdT9tVRcq0kTIxwfmmZaJsK6mHrq+pMcv0XEn2S5FsG6V+yX4pnd0jgLletm3n9sOVlxwrV765ubDoNDWZ9U1mPerrCot+fX1oPU5LS2E5k/k53NsXInXRVCRPOKiwPn3n03Afeh4A0HjUWMyeMiZfzaBaZB5/Ge6jLyF11gQkzzgiv6+ddjD7HTKYtIe0gYM7n5Qo14Le4/S5lFyXzuqhddg+qxSuLZJnWHJ/S/ZVguc2PvykztsjoGI7Z0VRlK6QPG8KAMC9fSHQlEXy9PFI/2oF3IeeR+prB+d/a++kZ08ZYzrm48YVOmZFKTWV2zlXMU1n/6oUlOf+KpL8FUrhvnLpKAL39ckh+Ss3bB33V6ikbo8sc+ebq0dyfbh2cl+z3L4o2Wx4G7j6JX+BR/mrm2L7ZWG7L9svoTCKpR7YUhUn9ZAstuRa+UT5cQLbMteZrA/kxW3oh8Ss44DqGrg3PY45v3kG2VYPqZMPQbK9c86ta0bjU6/i6kWvI+vl0PiVsZh9xGggS98FpM21teFtoPejpM0UyX0nuWdt719ufce9wz23URQy7r3KvUckX9HFUoG4MpJ2RkDHnBVF6ZMkZk5DTXUc2VYPNdXxQscMALMn7ouaeAxZL4eaeAyJqfuVsaVKX0Q7Z0VR+iSZWxcUOuZsq4d0u5QNAHOWrip0zFkvh8zC18rYUqUvUrmyNodEcpHIEbQMlUElAQoSebyaqZOjGAFEnJTGyUvVgmApuq3tuZHIc7bbcpK1rYTGlecotbRGJVRKlmknJxN3diyS/ef88DLsOSAiNLcttz5w3CTwq6EhfFtuX3VGdva33x6Z/30QjTc9jtRlJyAxazoyN8yHO/dhYMgAAEBq8etInTMJyRkTkP7Ns3DvWAjnc9shccw4U8+wYaSdgntHcv9K3iOSMpLnoKtDNLbBWBSuPG0X90zaHgeH7ftWUr+kTkt6X+esKIryGWT+90E0/tcDaPzhKUh84ysAgMSs6cDmLXBvfwoACh0zACTPnQwAcO9YCNTXIXHxseVpuNKn0M5ZUZQ+hefl8h3z5ScDmzYW1ifPn4olr7wFwCl0zIXf2jtoz4sQ9KYoFji+7zN6Us/GWzMv/IcoMotkPmCUOXVcGRq5TaW4OJH0JFJWR52S+cZR5vcVay4xJcpcWA46L5bKnbV125b9rPqjRGtzkbuSYRbJ+Y8ioYfdL+ycaHIvtpEw/kC7BPK1ZLiAm0criXCWIIlwbiXXqloQ3V+s+zfKe4cjyvzgMLlWMixkK/9y25bi+nNIZnpwkDYXa56zBoQpiqIoSg9DO2dFURRF6WH0vjFnTh6JEhFpKzXZmoBwUratkYf0963rjnKeuDbaylSUCPKfs3lzePk2U96nMmWU8yBpm6QeiRzI1S9Z31XjhMBxSGYjMHI3xVa2l0Sgc3DXQdIGOvQhMe+xlfc5JPdasWZ3SKw3w+4RyfuQG9bihtwokrZTCbqOXCtbW9Qo9qClkNZp9SWtXVEURVEUa7RzVhRFUZQeRu+QtYsVBWkbeRhFRqRyCufLa2tm0JnELTkmWynNtk4qcVFss+gw7QlkJaIRt051eD1RiJIRiosM5bCNBuaiq8OkYduhjGJh7WVMJGLboaYacv0l8jtXv0SW5ZTVKCY9km0pkshjW4Mfm/vBVjqmSIZeOGMoySwRdkYC2Zfk/HHXp0jol7OiKIqi9DC0c1YURVGUHkblytq20YucDMLVya2PIgdHMZWwiUKMksrQVqqVRHxKJFxb/1qJFMyZjVBsz7dEZucktNbWwqJDy7e0FBYDsnyUYYiA3zSzPowokmYUwwjb+872nqVSti22pj5cGySSrkQC5trDecxL6qd01fyEuz62EnGUWRCSITGuTgoniXd15kMX0C9nRVEURelhaOesKIqiKD2MypW1KbaR1VGiUG0jHCVI2mzj+y2RW2wlXIrEPIQikYii7JfbtliR6pJ9CWTKgEHK5i1mudpEEjukHt82slbSTpuUkbZmE7amMpIhAlvpkyOKJC7Zr2RYK8oQU5TI7ShDNGF12l4rTobn0lpybZQgmfVBiTK7p8Tol7OidBOpnz2KzE2Phf6WufVJpG56vJtbpChKT0U7Z0XpJuLxGNzrt+2gM7c+CffGxxCP6+OoKEqeypW1baNKbSN9Lc0vWIoloXdVrrf1mi1GtLgU28hRW7lTUqeErg4vAIBvlhMXfgXwcnCvfxTY0oTkuZORvmcR3DsWIjVzGpLnHgk/irFJMUxDopj12Ebcl+K6RZGjJUNTxXgmP4tyHaPt+7GzfXJlbOVr2/NtO0uAppWlMyW4+ovxjAmp3M5ZUSqQxMyjAQDujY9hzr2LkW318h3zhUeVuWWKovQkVEdTlG4mMfNo1FTHkW31UFMd145ZUZRtqNwvZ9uouShR1hL5zTb1WJQJ+MUgSrQ2pVgp12zlMYokSthWmpIMa0jMKWh6ygH9AQCZ6x9p75irkG1tQ/r+FUhcchyArUxIShFV3Bmc1EnkecQtZwDQiHVixMKdM9aIpVhEiaYulkEOV2cUmdp2XxJjk7BhnGK936K8O6K8M2l5eq/ZDulwdRYJ/XJWlG4kc/0jcH/6EFKXTEfTqhuQumQ63LnzkPnZo+VumqIoPYjK/XJWlAqj0DF/92tIXJSXshMXHwvEq+DOnQcAmH3F6eVsoqIoPYTK7Zwl/rISiiUXR5Gjo5iQhJUvVrRoFLnN1ighinmAZNghisQtaTMHOZa2qio0XnEaZn//FFCH69mJs+DX1aLNy9mnj7SV/cLOA/2d+Hw7Lc1mPZd2kkjcfkND6H4cUmcgOjbg/+2Y8matvdd4sa6t7XMTRcoutaEKRVK+s/NcLIMOyTszioxcLGm6G6VsSuV2zopSYbg/Oo39LfH9U7qxJXJS1z2CeDyGxDeP2ea3zA3z4fmAe9mJZWiZovRudMxZURSWeDwGd+7D2xqn3DAf7tyHEe/GeZ+K0peo3C9nSRpCWobzd6bb0vK2E+dtoxMpEk9aKjFWd+JVLXlhcuevWFGnnDQmkdKiRL5HSU9ZrOjxKFIjkXcDUnKxZLyw+5Gsc2jZLc1InD8VaG3LG6c0Z5G8YCrSv1gK94b5SM2ajgT31UyjsomPuLNuvVmfJWXqTXpP6ike8Bqnbasj6UCjzDbgnk/baGCJ5M7tV4JtVHSxPPXDykSZISB5H1KKNZTBtbmVvC+qmTSbkhk6JaByO2dFUbqFxMyj8x30bQsw5+6FeeOUWdNDpW5FUYqDalKKonRK8oKpxDilqssdc+OdC5G+Z1Hob+m7FqLxjqeiNFNReg2V++VMZWpOiuWkL9vI3SjRety2VE5xmHqyjOTSmfQsiWSXpHEsRYSjZNsoxhOcDCaR+bj1thH3USLJIShTLIm7ZlsZz6fpK/uZ5yd9yxMB45TMbU8i8a2vBsqz9x2J1o43tcD99TPApiYkjtm/sD7z1Otw71uG1IwJAbnbbzdu+cz6ufUcxRpCkTwfHJIZAJL7N8pMD27Yj2tnx3KUY7U937bvbe76c+cvLnhfRJnpEYHK7ZwVRekWMjfMh3vT40h961gkZk5D5s6F+TFoALOvOMOqruQphwJAvoPOtiFxwkHIPPwC3IeeR2rGBCRPHx+YZqYofRXtnBVFYemIyu7omAEg8a2vAgDc6x+FX1uLxHdPsqqTdtBzHn0J2Tav0DEripKncjtnTh6xjTaOIh1K5B1qwECNFmikKlcnab/PSUBh2xbL7zqKrMZha0IiqYfbtlge2lGi9SWw55yYfXBVFrttRN70q6rQVlWNxh+ditnfOdF80dbVYXbj+fAbGuB5ueDwUdg+SSQ26msBAMlzJmHOgyuRbfNQUxVH8tzJpgxjcsLWT+VZj8rC5Bucyu+S59w2nWkUumoG8lnlafslUi/nqc4Nf9mUlaR65eDKSIblbOuMMlxUAom7cjtnRVFKjvvDU/MLIS/4xA9O7XK96V8uL3TM2TYP6fuWIjljYpfrU5TehkZrK4rSraR/uRzuL5YhdephaP715UidehjcexYjfd/ScjdNUXoMlfvlXCz5wla+tPaAZqRsKr81M7IckfSoOUTAbziwr5D2207ctzVKiSKVSyiW93kU/22KZFvJEABnPJIVROtyRiVUDub+7g67R2h9XLS4rZxH5fHBgwvLmZsfz3fMl0xH4tzJ8AEkfvh1YMRQuD+bDwxowOwfn2nqkQxTkDIO9e4mz5Ifp+eGUOphHA7JvcaVkbRNEpEu2TbsWpfCF5yjWNHxXJ0SrGdcFIfK7ZwVRak4PC+X75gvPhZoMq53iYuPLfyuKIp2zoqidCPurOnsbx0dtE6lUpTe2DlLZCqJRMTBmZ/YShxE4nY2bDDrNxNZjkSY+lR6pLJ2ZzKRrRwZRcq0xXaIgCLxu7W9F2y9tSm2EeaUQOpESVQ+U57z4u5MBs9ZdofsvcPsh0Rz+yNGmPVRomyZ8+TX1haWnVZShjPZ4JBIwcUiimmNpG22En1nUrIkwl3SllJ4kEsolm96lH5EgAaE9QAa71iI9N1Ph/6W/vliNN4dbneoKIqi9E60c+4BxOMO3Nu37aDTP18M965FiMcdZktFURSlN1K5sratvMBNyqeyhsSj11YqJb7ZPo0qJVJi8uRDgZZWuLcvBD7dhOTXDkb6oefhPrgSqdPHIzl9HPxWJtI7LH1ksSKoufW254YrYys1cm2QRPRKoj5tzSZsZTlBRL91pDclYFrihy+HyeCcBM5txyEpT9tIbyN6PVsZgx7JcA417pGkleSQDC8US/q2bZutNGx7j3dWZxQTDwkljoK2lvkl/YVGa/dekmdOAAC4P1+KOQ+/mLc0PH08kqccVuaWKYqiKN2Nyto9iOSZEwqOSTVVce2YFUVR+iiV++UcZQK7bWQdV14SxRdojxO+3JCX69L3LApaGj76IpJnTWov08+U51JMdrQniuxMKVa0uyTS1DbKWrLfKBHmxZLWJJ7hkmhpTrIOGJgQObiGeEnbGJVI2hITxEAEZHV6Hcj+W8w8Z2fjJrOezH8OQJ4Bvz+TSlKSGpT1suaGBSLIuFGGTbgyxYpyl+zLpu4o+4xSTxSDIcmsDw5Jys0I6JdzDyF9zyK4dyxE6ozxaP7dD5E6Yzzcuxcj/Ysl5W6aoiiK0s1U7pdzL6LQMV84FcnpBwAAkqceDtRWw717MQAgMfvMz6pCURRF6UX0js5ZIllJDC+iSCKWad/8AQMKy16/fkhddiISlxwH3zMSZGL0F4DBg+HlcvD7NXTezo5jLJYPNqUUUaFRTAsk161Yx0vLUCmLRBU75Fh8KilXW8pdXLS0pAzdL5W4WanXke9HAldPIELb3N9UynY++NiUWU8k7hrS9mFDzDIxG/Elz7NoRkIJhj6KFVlt678tiSq2HVYKW8fNHLF9j9heQ8kMjSj5A2yNRyTvMkt6R+dc4bjfOYH9LXHp8QDU0lBRFKUvoZ2zoig9gsa784Y7yeMP3Oa39C+Xw6urReM3ppWhZYrS/VRu58zJFJE8jouUzkyynspyxEM7UqrCjvXFSmtWrGh3idxmK3eLPKgtfbO589NMooo3EcmVyrI0IprKyzTCeOBAs77OXH/eMITxqpaYhtA2ULj6OysriXDm2kLbTutpaSks+v/+GPFNTXB/txL+vz/F7Clj8lUOqEHmiVfgzn8JqXOPNJL3kEGmHmpOUqxoZNsoYa7+Ys2KiDIsIzFm4ursbNgsFiFK2Xa4MIrph+27gA5fFTvCXUjlds6KovQqEiceBABwf7cSADB7yhjTMU8fh+SMiWVsnaJ0L9o5K4rSY0iceBD8jS1ofOpVXL3odWS9HFLTxyFxzP7lbpqidCuV2znb+qBycGWIQQJq68LLiAwmLH2raT2tRFqRRJJ2lK9lPIVtozOjyH+cZEWXufSbFIlsJ5H8JPcFs94h8quznqT3fI9EGG8m0nc9kayHDzbLcSMB+5xpASkDn0p6jEFGwJCGyMcSGTxsHSd7U/MQDkm0djO5DnHiNU/KzJ4yptAx11TFTMdcJWhDoD1lMqGxlbtL4YUvkYC7OjMjykwWWyMW2+O23W+xosdLIGurCYmiKD2KOU+3d8zxGLJtOWSeeKXcTVKUbqdyv5wVpcw0/moF4jEnbxizFekHnoWXy6HxkullaFnlkv7dSjQ+9Soajxqb/4Je8Qbc+S8BAJJf/FyZW6co3Uflds5RJGUOWp6Tsil0v5zPapQUhpyBBSfXdpSndUjSnVEk20raUhOSyvKz9sVN6JfI1xy0bZyELpGjqNHCxs1m043NcB9/Gf76Jvx47BcL66957k00LnoNjZP3Az5YY7YdNtQsS46Fi6am66n0zcnQVOJuC7m+nDc164/NyOS20dr15BnbeXjeKe+3zyF15hFInjYeAJDcbxdgaH+49y4B9hiJxLfzf+ywpjwU22EZ1r88QrQ2d6+VIqJbco9HkdY71ktmX4Rtt3V5Cmf0I4mslvhj276HizWjJwKV2zkrSplJTBsLAGh8/GX4m1px5RGjcfXy1UgtW4XGyfth9qR9y9zCysLzcnkL263mOSdnTCj8rih9Be2cFSUCtIO+5pk3kPVy2jF3kcYLpuYXPt24zW/JGRPg77pzN7dIUcpH5XbOnIFFFG9aWzmKwsm4tHxTk1mmxiMSn1ibaGZbj1hbJBGaXHsl8rXEYKZYaTEF2/pkiMOhZVrzcm1i8r64esGrhSCmxNFjTZkGIt1yZhmcfE2lVRrFTfzXg+XDr4uzbp1ZptHm7XKzTw1RBhtzD+r/zj8/zP4ZmdKhz8AG0glTL3Aa7T6AyNcUeg4kwykiWdPSJFcyNFWsITfJthLzniiybMexSJ5/SpRZH1FmwUSJDOeIsq0lGq2tKBHJPPWaiS72csgsfK3cTVIUpcLRzllRIpB56jU0LngVVx0+Ghu+fwauOnw0Gn//qnbQiqJEonJlbYpNurOt11unlWOQSFzET5vF1jDAhlKkX5T49tp65RbLT5fD1qCB+qCP3L6wPOeuhWhc8CpSZ09E8rhxAIDGcTsivtcwuHcvhjNyMBInHWG2pTKxRMrmorI5oxKyGJCy//meKf4eiR5vysvNzhAiHe883CyTlJh+//6kXXbexFTKdj76xNT5t3cLy94/TXvpccR2NG1zdt/B/LCDaac/iHiWt3H3ryAVp+0MEMl9LRnekQw3RTEt4eqRPGdh+7KV7W1NS4rlZS55zqO8UzRaW1F6Jl7Oz3fMZ04ANm4prE+eNSn/u6eJPhVF6RqO7/sV+Qbx1szrvFAUK7wo9nPcV2OUecM2cySj/HVvGxRRrHmckm1tA1Eoki8DW+h8TDoXmthSBrJPcThMG2jQk+TLj36tvmu+lvHm3wuLLa+YL+eWdfn99tvJ1Ff1xe3Mdl8eVVj0tx9B2iL4siFtd9auNct/eaew3LT8/cLyh383X+Yxx7RnxCgzr7z2QPO17Py/XUzbRpCvaDborkwjeLb3ftMWvlwHnAeDJJAySpBkx/1ViiA3bp+S47ANCLS9Jpbv7fh2J3ZevwAdc1YURVGUHobK2orSB0jNex7xWAw/2HnUNr9d/cxqeL6P5Hidm60oPYXK7ZxtpVtJIASVL2hWqrjgNJUiI4tt4FJHmWJJuBJJSRIcQokSgBfFgk9yLLaWfYHMUhGSztOgLipxs4FfnbfZIWVy65sQy3pwn3gRm7/Ugsu/NAYAsH5DPW7828u4/m+rccU+Y7Dx7TgGb0/sScncY3bsi2mLQ4LJnGYjt+c+WF9Y/subRo5e9pHJ3lVNFPyprR8VlkftZuZFO7uRIQXJfHnOplMCN4xQimxF9f3McjN5B0nqsQ2Mpdi8T6MMg9m2xWOeW+45LNYQJFeeW1+CYZPK7ZwVRRFTcDJrz/B0+ZfGtHfML+KKfcbg+/uU56v5lrdXIu7E8Pl+X9nmtyc/WoY/N23EJXseGLKlovRutHNWlD5CYtpYbPlHDv/1x9cw98+rkM3lcOmoA/H9fb7Y+cYlIu7EcPM/VuLo4XU4aviEwvonP1qGxz9egksHases9E0qt3O2lTg5aMQttTxsbiF1EnmvgcwJbSXbxhnJxVZml7TfRlaSSLVcuyTrayLIubYR2pI52BRryZ2JiJbIYNSO1efkesaOk8JFaAfa2Xl76Nzf2EgjGaeP3xtz/7Iq72gWi+HqqXuheojZZ2wXM4/bH8BkfhJIeH7AgjE829O6lhp8fcfxaPbiuPtfS7ChFThk8ES8uH4pln+6BEcMmYRzP7cvNhceM/JMckiGRGiWLE7iFmXkKkE8Lb2edUxUdhTZXCK/d/b82cq/UaRjGpkuGQaznYXCbUv7BUl0erEi1QmV2zkrimLN1c+sDliNXvvKG0hOGV3WNp2186H468ZqPLtuCZ5ftxwePBwxZBIOHzIRwKdlbZuilAudSqUofYT0b59DasVquONHY+MPz0Bi3GhkXlqNq59ZXe6m4ZDBExFHHB48xBFv75gVpe/S+76co0grJMI0sEzLtxBpjRoe2LbHNlMLF6kYFoVsa0BgG/lOiWJ2YDsEwVEsSYmzzgzIoFXhZTgpm8JJ2ZIyVO4WXEd/ILG03GcvZG56DO5vnkXqoqOQPD+fmvE/jt0H1fdsD/eOhYh9cSSSF0yFP2yoqaOByQglkVWpzD+AGIzsOqywPHpXY0Jy2ztvw4OHKieONt/DP1oW4dSRh2O3nYyBSWwHY5DiN5CoZu7e5Ow7Y4LrwEV3c/dIYNvOq2exlalt733OvKOrM0aKZSVqWybKsJykbVwEOEVi9xqB3tc5K4qyDZ6XQ+rS45A8fXxgffLcyUAsDq8EY2ZSfvLmKvz6vddx2sgjcMrI8Xjw/RX45bvLAQDjP79b2dqlKOVEO2dF6QO4lxyXX/h0/Ta/JS+Y2s2tMfzkzVW49k3TMQPAqSMPBwD88t3l2PWNDfjBl8s7Jq4o5aB3dM5RpBUCNW4IyHJMhiLraEAOSTSwjQlJlAhOShQDFVvZnju+KL7AJZCaWCmTQo1EqNwtkb65bW2NHwj+UCJVU7m7s3pso5QZmS+wz712LSwOPRWo8d9C6svjceW+owAYP/BjMAqfX7QRuUF1GHx83tfbH7WzqWfoEFM/fSa5YQcKd44p7H3NDHdEkWVtt5VEVlMkkrUNkmeeRjtz+7Q9H1yGL9t3b7GulUT6jkDv6JwVRalIGk/Lfy17f/lwm99mTx6D+B7bbbNeUfoCGq2tKIqiKD2Myv1ytk0fKJAs2HRzEaTybqUzWZtbT33Eq4lUw8lUEmnKJnn71uttZX5bYwiRvy9jQsJF6wbW58LXc17ZFG49Z65AkRy7zTABjRAPtIu5/oL7zh9GIq6pUcoX9wjd1CfDSz5Nv0nvU07KlgwvSCRuDlYuZqK7Jalk6TWRyKaleDd19dkqtYxsa1TEtYe+y+g55t6DUdLrRqCH9S6KoiiKomjnrCiKoig9jMqVtW09YimStIJU7uAmmwfMSYgkUst44kaJypR4vXaUl0yOD/hCC/yxbSM7JVGktrKWrdwVxeSENZjww5c58xC62lZO5VIVUool9YX87mw26SOpVOvT+5ub1cBBy5BhpMCQkkQe5QxGHEEbqA++xwwRUETGI7TNgmGlrpp+bL2+FFHiUWaedFCsSGZbH3FJee5dRu9rbuhI8j4tEvrlrCiKoig9DO2cFUVRFKWHUbmytkTysZV2OMlC4mtdzcjgtnDtl0RIh5W1jfK19Yu1TdcWxY82SspNiakEhZOUJf7YXBvi3PGS8h4TucvVL2lDZ23j9sN5x1MpmyLxYi9W1HHg2jJR8FTidjp5ZrYuww1HcBI359fNRv1bysvF8rCPQlg9kohodjgigrGKbbreYsn83PBlCUxI9MtZURRFUXoY2jkriqIoSg+jcmVtim2ENrc+ShQk1x5bmaVYHt2d7Uci7dtKNRI5XyJ3StJTSspLjnfjpsJiIDqZwkUV13DybvhqNjKYizDm2h9l6MFC4vSpmYZEFpaYx1Akx2H7nHBR8HHL+9rWkCSKz7bkPEiGjCTPehRTH5uUkZJobdv3J217sSRl2/NXYimbol/OiqIoitLD0M5ZURRFUXoYlStr20Y4FkvStY0q5IxNKLYSbWeSYRdlzM+kFF7jErmTk7giyLnOxo1m+b0PTJn3PzbLWSJTDhtklkeOKCz6I8xyIIKZk0QlBhkS4xHbKHcbExIuMhlUtiVRypxcHMXgQuTXLTAekUjZtt7arJ+64NpyntuS+gP1MMfF3RecgVFXh9Ykkjn3rpNgOyQSZRihhsklQLelkeGcrF2C9LT65awoiqIoPQztnBVFURSlh1G5sjaHrVTT0kLKEEmJ81m1lTKiRH0XA9v92Jax9f8VyX8CsxHJNeG8yddvMMv/+tAUeclI3Nm1pkjdzkburjqA3C8NDYVFmv4wIJVyx06lskB5gazZ1cjarQmLHif7dEgdfqBu2i4uQj/CkIXo/mJSdEraQFNhUlMZKoO3tpJqGKMaDjbqlzMwoZKrIOpbst9SSK6d1cNFaNvel5L7IkrqRlszIy73gEYZZwebAAAgAElEQVRrK4qiKErfovd9OStKF0k/uwpxx8GVh47e5rc5y1bD83P4jwM+V4aWKYrS1+jdnbNETuH8g22jAW33K/G87qrfsK2kJdmPrVeuZF8Sv2CmvEOHIzZvIW0wcmFAaqbSFJEs/TXGhKRlbTV+8udXsWVNFU7f/ojC+gdfXoJrVq3Cj/fdF/56YlRC28BF/caY45JEbkvuQXpdKFHMZDpoaiosOuQcB+TuISaS3e9nZP4AUXyzufV0W24YQfIc0GvVSiRlGn1P5f/AvrjjYqKyubSSpRj6sq3TxoyJrmtuDl9v4+2+9XIxIso/a1+29whHMZ6xz6q+6DUqSoXy3S/sBwD4yZ9fxabmWly060G4/Z0XcMs/8h3zD0Zv+0WtKIpSCrRzViqW1Nx5iMdiSFwwdZvfMjc/jrbqarjfO9mqTtNBr8Sd77yIVt/TjllRlG6ncjtnW8MDiezASRzcJH5uX9wkd1sf765GTkeJjqTYSj6SSFzbOmkZGuG8cRPibW1wb3wM2LAByXOObC8fR/rup+HevhCp7xxfkGP9gaSeehKJ31BrVg/IS9ZXjtsb1//1dWRzHmpiMSQn7YMOw2xnh6HmUPr3D2+zw9wLFO6ce8z5aSKy8idrzPL6jaS8kVP9oUPM8uDBn91OEr3sfLrOLP/5bdOstz4x62vMfmJ7ESOWUbuE7j+Sb7atNM3JxVx0PIVGbnM+6BSJkUgg0rsbpWmuHltZOexdJpkdIUHSLtuhMtsytvuVGJsUicrtnJU+T2Lm0QCQ76ABJM850nTMF01F4tvTu1Tvf69ejWwuh5pYDNlcDte88AZ+fNCXi9ZuRVGUztDOWaloEjOPBpqb4d75NOb8fAmyrR5SF01F8rwpEBhhbsN/r16Na1atwuWfPwCX7jUW1//fq0ivfBkAtINWFKXb6H2dc5SJ6lx0Mifd2Mq4Er9WSlelmChRnlGkMUmdkqhjbiiAicpNnjel0DHXVMeRPP+o/A804paU94cNM1XuvXth+WePvIhrVq1C6qRDkJiWH3v+bxyIQc8MgHvvElR9fjskRh1l6mxgopNtI9g5SYyck9i/3zftf/0tU+Qt4hNeZyTU6n13MPV8aZTZdqiR5QttI7Kw864xYln/mDFoefmvIwvLdXEjg4/d75+F5fo6ct0GGMnft5U+RUMxjFlLfNuiAILR+oH7kRk2kcCZk0j80W2HmyQzG7htJdikXbWVfzlso6nLlSdAMntAvbUVZVvS9ywqdMzZVg/puxZ2qR4vl8t3zCceFFifnDEBqXMmwSuxI5CiKEoHve/LWelTZG55Au4dC5G6cCqS505G+t7FcG9/CgCQuPJMq7rckw5hf0vOmAAAXZLKK51rX1+FD9a+jRk7H7btby+9AS/nY/ZBGs2uKMWk93XOtpPsO4tM3Lo8RTJZnpO+udRjtpHnnZkERJGgbCfZW/sjk/VcijlaD2mPP2ggMnPnofGG+UhddgISs6bDR3uH3L8/3J8+BH/IYCQuP/kz2+PvZORah0YY02ZSo5o6E93NHS/1oXZaiElDXCAdEjHLaTKR03jXSMzrlprI7df/sVNheUC1MVf58qb3Csu1gweYtoXI2k4TMWX5aH1h+Y9/3x4AsGbdANz772fwx/XV2H/gBFS1N/Gl9cvwwobVmLnrIfjj6hEYO+5TU/fu4R7kJfF/jnNaNkHyfNLrwxmPULj11JyE89OG5TMaGBoQ1GMrxZZSVraVkSmSGS6S97mt4YptOzkzoAj0vs5Z6TN4uRwav3cyEhcfHVifuPR4AECb1ztl6P9843XEHQff32ffbX67853n4fk5/Gz/USFbdo3zdjkEqz6twUsblwAADho8ob1jXoKZux6CC3c9uGj7UhQlj3bOSsXiXn5SfoF+nbaTuPR4+Jw1a4UTdxxc88brAIAp/U3g153vPI9b33kOM3c9tOj73H9gXtZ/aeMSvLJxOXLwcNDASbhw1zFF35eiKJXcOUvkHy7CkYuOlcg8lFKkY5SU76yeKO3ivK8lUpdkIr5EHqf1cNew1sjLPhs1zaX6C/c+9qlkzXllU5nSYeQxItH79f1McU76kgyDNBvp+cKdD0ZTczWueeMl/GWHwTh++yPwyIfL8dAHz+GMnY7AMSMOR9Mn/yqUr20h+w2Ya+TPJ42mjhFTloZqs119lYPDh07EqxuXw4OHOOI4ePBE1FURc5Jactzk+gSoIRH0XHpEidQYD4/ED0DLB/zOyRAKt63E+9znpGOJnzY1KmG8uDlY85MIzzpHZ0NbUYIkbaVjiae/rRc31x7b+5EblotA5XbOitKHuWTP/QEAc/9vKR79cAXafA9n7HQETh15eMn2+fy6pYWO2YOHF9YvxYXYp2T7U5S+jE6lUpQK5ZI990eVE0eb76HKiZe8Y165fgkOGTQJs3a5CgcPmoTn1y/BLW+/WLJ9Kkpfpvd9OXPSqkRy5SRFul4SYSqJiIwirXcm4xUrLRtFIofZRn9SJKkkbaUsifcxjfSlMiXxmw6Uqe58v4GUimS3VD52BNefyvXOLtsXlnfa500AwNXPrUab76HaiaHV97Byy5P43t75ILGBB5rxdn9ns23oLAFyfP7uJvp776n5ce05i1dh5frX8J09x+Hbo76AmPMBLsEXcMNbmzD3rRcwfFQWs4/cFxhlplMFZG3umthGBRPvcPZeYIdiEF7GY9JEckMZkshwShVT3taoJIosS7H1gA57Z9j6xXNlbOXoKOkuJYZUUdLraspIRVGAfMf8H8+uxmV7jsOsPQ/ADW+9jGv/8BIAFDroYuHlcu0d8wGB9bP2PACDd2tTcxZFKQHaOStKhdHRMV912GicPSDfYc7a8wDU1bbh2j+8BgDIjB9XtP1dNWU/vL0sPPJ99pHF/UNAUZQ8fbNzlkxgJ9NzHBJVGpDrokQb1jEmJBw2Mo6tHC6JcJfIOVFkOLov7tyw101iQiGQEQPe3YLjlZxb4ulMDUl8Ii8H1lPpm9xrud13MXV+YXukvnQUkudPBdYa05Cr67+G+l8Mgef5cCaPNXUSL/HQ60il9B1MCsj4VCNT77n3x6Y8NVwhknlue5I+0tZURCJfxpkhDgZuGMEnkbVOM5mGF6iTtp+RcbmIfg4anS65ZzmDEQm2vv+Sd0PYsBmXj4DWTZ9nThIvlhe35N3LveMklNr3m9A3O2dFqWAaLzyK/S151iQAfdNmVFF6ExqtrSiKoig9DMf3/Yr8I9tbM6/zQrYSLYVLH1ddpMnmxUq1RumQlSS+4FFMU3pwmjU2lSBnSML6IwvkK2rowdwX1Gebk7i58jTqO3AvNzWZ5VZjTgLqiMbJjZTOzj/Zv0P26VNJlh435/+cJW2kzxU99/Se5SRfJu0jl5IyIGVLziuVpum+JGY8dFt6vNR0hYO7TzmTllJgI5tHMeugFCtlZJSZIbbpNwX7ig8/KbweS/TLWVEURVF6GNo5K4qiKEoPo3IDwmxlEM5IhIv0YyS0SDIxR7EiFTukQVt5RmKU0l2+4J8FbQ+NmqdGEoF9WUrZgYhbidwdfj59wbCCz913kmvHpWCk58E2WrcTfE4y56DSbpR50EyazUAkNnPPUl/zwBCEbbSu5JwFJHpGypaY4kQxaSnWfPPO9mX7DNsOZUmeAYmZisicJoKxCaUEc/31y1lRFEVRehjaOSuKoihKD6NyZW0JtpPEuchNAo1apZKbz0mNtpIOjWYN80EGOvfNlUy4L4U8EyWKW9JmukwlXCoLcsYQ3Hoqm0oOnZHHfObaBny2qbTKyLVOzlKuk9CZBBjlmtte26q68PXVnBQcHpXNeZMHhhTI+Q6YjXDPoUT6pHBlJGYjbDpTgsRoh5PBJXUG2mMxe8N2yMR2pgx7XgVDk5Ihyy4O7Xxm+RLMPNEvZ0VRFEXpYWjnrCiKoig9jMqVtamMQE0WBPKC09Ji/iNJ3bhundl28xaznkpxVH4bMCC8HomEEmfKS1LAdZQJi+Demijylq1kZTu8QKNdRan1qLTHpfoj5Z0IspZEvibrA3K3rRczxTZyd8OG8LbRqOv2e8ehRiYSuZhKsnRWQ0C+ZgxJKE7nUqNPfZnpMBJj6CJJxUkJSOX0B+6+CKQVZYZNAkM0TEpKOixD98XK+4JIb860hJPH27hZDoIo586wNfewJcqwnG3ax1IbwDDol7OQ1M1PIHPrgtDf0nc8hdR1D3dzixRFUZTeinbOQuKxGNybHkf67qcD69N3PAX31gWIl+mvK0VRFKX3UbmyNpWyJdF3VMrevLmw6GzcHFrGH0Sk6TYPiQumArkc3FueBFo9JGdMRPrXT8O9YyFSF05FYtZXw6XKKBPYRdGvIfJRlFSWkiECW4MR63R3TLQrJ9vFSRkqF9L1XOS2xHgg0LbOZT4nyjUvVlo8cuw+PQ9kNoDTYRQSeDbMsE3gOBqIoQeRxn3OH5uLoJccByHgj83UE/DNFsjytIwjeY9wQxCcmQ2VpumQAa2Hnp8Yc/9ycjSVuDm5m41mFkR3dxYJLYl8tn0HRfHcj2JyUqzIbYkpiiWV2zmXgcRFXwGaW+Desxhz7l+GbKuH1IVTkTx3sqboUxRFUYpGn9diG2//PdJ3Lgz9LXPrAqRufiKwLjljImqq48i2eqipjiN57uTuaKaiKIrSh6jcL2dOWmFkx4BE12KkrPiWJri/XAFs2ozkCQcV1mfuWQT3rkVInT85IFOlH1xZ6JizrR7Sv3oGiZlHs6YSIpkyit8st6/O6pCYfhQrXZvEy9hWtqVwciEHF3HLRcpzkjgnp0nMEjgE15nz5Q5IutQUh0qr1ESnXcJ2/vWeqfuj9WbZMefS2X6wWb/DMLN+MFkfuLZEhrU1a+HKEEmeSxNJCUSYx8Nnd3Byd/BeDq1+q51RSZesjzPmIZJofVaOFnhxR6GzZ13yHpEYgHBwz4/k3WRrcmT7HubqLAGV2zkXieSphwNAvoNuyyF58iFIP7gS7gPPInX+ZCTPPrIgWWdufRLuLU8i9c2jkbjoK8jc9TTcGx8DACS+//UyHYGiKIrS2+jznTMQ7KDnPPQ8sm1eoWPuIHPrk3BvfKzQMQPIfzED+Q66pgaJS4/v/sYriqIovY7K7Zwl0ieVyqj8R8u3R0Emz5yAOQ88h2ybh5qqOJLnTzVlGvrBi8eRuuxEzP7eySb4q7oas5Nnw2/ohzYvFzR4CGmDaH2USOjOZJYoqdIkpgJcxGIUz10aySoxs6ByIY3KJ9KuT6NpOU902mZPcI4lZg2cVC4xgyDyqEPOm0+NObh7nEYnU8OODz4GALQ8/XZh3durjExdV2PO2c7jTJmq8SQSnN7z9LxyaRPpMZHr5lcz54x6zVPIueSi4wOR3uG1BKVs2wh6yQwAj3kmaHlJylMuQltiQkKRPN82xiO0Di5VapQoaNthNg56TJwxU5ThPa7OCFRu51xk0r9aUeiYs20e0vcsCgR7ud85AUD4Q564/ORuaqWiKIrSF+jz0dpAvmN271uG1GmHo/mB7yF12uFw71iI9D2Lyt00RVEUpQ/SO76cJWYNtMwAI2WmH3s13zFffAwSFx4FH0DiBycDOwyHO3ce0L8/Zv/wVLNtlLSLtlKMRBoKk19spXFJGYk0JUnFZx2ZzpiQVDEGI1Tyo3JhoA1MBC0HF8VN4c4blTWzJGo6zAxk6/qpfF1ba9ZTKdk2EnaLkbVzq98BANy/cFRh3X/968+m6TDtuurdfQrLZzT8w+xy+BBTd//+ZpmTeSmS9hIPbdZLgEj1AZjnh40G5+5TyXoJnNd7oAy9v+g5ZIZ0bKVsyfuxs+tla9Bj+96zHQaT3F/NgntEUk8xfMeF9I7OOQJeLpfvmL8xLXChEpccV/hdUfoCj3ywFGua1mC7+r23/e3D5cj5OZy4w8Tub5ii9EH6fOfsfvMY9reODlrdv5S+QMxxsKb5TQAIdNBrm/6Ehz79E76mHbOidBu9o3OWRB6TaLqArNWfeGhTbD1Xu5reUbovTtIJ268kCpOjM9/uzyrPRY6yxiNUqqP7ZTQ/iRzNpN8L+Ev3E8jCNEqYytqceQR3i9DzQDysnU9JGtIPPzZlthCf6wHEz3qEMf7wh21ntq0Kj9aW3FMtf89LfU++m29jFQ5HLPYi1jS/iU+zf0cs1oBcbjNyuS3Yr/9EDMIELP0QOOV908YaNpUhYzzC+VFHIJD2kbnHOYMRn7nfA+trwtNTsnDGNiBtYI1zmOeJi9C2NeCI4ittM2xWDNOkrctI3l/cu1ESSS6RrLtRSe0dnbOiKEUhFsvHY+RyW5DLbWlf1w9j+k8oZ7MUpc+h0dqKogTo6KC5/yuKUnoq98tZIr9G8Y+m0bQkjR42bjLL9XWFRZ94DLMT0iUyMcU2erDDM9hWjpas58pw51UipdEo5cAxMfJ1INqVSbNHpe9qxgiDlaYFHtqcLMsZT1ADEGqK8td/FJY3LzTe1h++M7CwPHS7dwvLgya+b7Y9bHRhOWACwg0f0PXEHKR2z/y2Bw4365Zkd0FTy/vtAqwDwEfcAfYZYqTUqh1J5Dg9x5Jo4eoSvHKoEQtZLTEYYf20Oc/yaubZpvVTL3MqZXNmORQuzWlgX4IomGJFSNvUY+vFL3l3cBTr/WXrdx9lNosl+uWsKEqBppb30ZR9D/U1IzGw3xdRWz0cLa0fY+HHy8rdNEXpU1Tul7OiKEXl6U+WFjrm+tod0eY1obZ6OABgwSdLAABTh+vYs6J0B5XbOdumJ7OUQRwiXzvvGHnR/yeJrK0nUZxf3M2U2XEHU4aTuCXpI7noRIl8GbYfScQ3B3f+uLbQOkmawmBqQCLh1ZPIZDYylSxTKZuLauWCu7n0nlHS0Amg91Trax8Ulh963piALP/IHMtODab+b7X8o7A8Yq81hWV/xAizgzozzMLdUz7xEo+N3QMAcMm0PwAA1q/8BJ+rPwxnf+5QAECLZ07gitwT8HKfYOa4/0P8gC+Y+sjQDitNUol4A0lJOXAQig6TGlIUiUuHIKJENXNpIimcxC1KJWnpp207pNfV6GTJO9bWkEiC5FpFMYyK4qcfgcrtnLuZxl8sRTzmIDH+S9v8lpn3Arzlf4LbnqVKUWyY98FSxJwYjt/+iG1+W752KXK+j29h95K3I3HIaLz44sjQ367Y/8sl37+iKAYdcxYSjzlwf74UmcdeDqzPzHsB7u9WIl7ixNuVTup/f4fM3Hmhv2V++hBS1/6qm1vUc4g5MTz0wVI88uHywPrla5di6doliDmMdaOiKL2Wyv1ylnjf2vqm0nqajNmA/8GnSEweDWxqhvvQ88h92oIrx4/GNS+8icanX0PjlP2QPPFA4JNP8xsQkwifk7WjyCycXNeZ9y3dTiK3R5GdaEq/piZU5Ty4P30ITlMTEjOn5dc39EPmhvlonPswGq84zWxD5W6JxG2LJ4ig5YwkGAOLQERvoHxraPncFlP/wYMnYVObg4c+WII96zzsWXcY3mp+Fm81r8D+AyZhr7oJ2LLFRGsHpMws9eg2ywFjDua8+e3GJnUnGDVo/AFk2CZH6t7DfDn7O25vlmnKTWr6wtzfJZGyGXwyVELNQ+gzSc9Z0BiEeY94zHWmSGRhLt0ktx7kmkuitSmS2RsSiburdUikbFt5OYqUzcG1mTMwsZ19Y0nlds5lIHH8gch90oTU8lW45tk3kPVyaJyyH2YfuW+5m9bjSXx7OgDAve6R/P9nTkPmhvlw5z6M1GUnYPb3Tyln88rOlGETAQBPfbIEf2t+Dj487D9gEsYO0AAsRemLaOdsyZXjRxc65pp4TDtmCxLfng60tsG96XHMuf33yLa2IXXZCUjMmq7+5ch30As/WQ4fHhzEtWNWlD5M5XbOnERrK7lw5UkUqjPALF/z6h8LHXPWy+HqF/+IxPRxAR/kQBSyrcwiKd+Z2Qcn+UvOUxSphpOgiNyZmDW90DHX1FQh8d2Tti0fqJNIslRGpEYPnNzNXWc2WpvuN3xbnzn3VEINGNgQ0w8MNpJuzWiTavH4P3wIALjxby/Dh4cqJ44230Os+ve4cNeDAQC7TDHX0R9ijEq4eyEQbUxkcIdEznes94cNNet2GG6WSZpKP3CsAuMTSgn8tG3xa0lUOfVNt5VZufShtlI2Bydxc+YktmpqFGm4411iK5OXgmIZiUjesVnmfinxMZb/qakg0g88h8YnX0Hj0ftjy/+cj9QJB8J9+EVk5r9U7qZVDJmbH893zNVVyGbbkLnu4XI3qUdw499exvV/exGnjpyAX439MU4dOQG3vrMSd7zzfLmbpihKGajcL+duJv3Ac3B//Qwaj94fia/sBwD5L2YA7sMvAsMHIXnelHI2sceTuf4RuD+bj9Ql05G4+Fhk7lgI939/BwCYnTirzK0rHx0d86WjDsT4weMBACfvOB6Dq7O49Z2V+TLYdgqfoii9l8rtnKOkQuQMOKhZA/XK/sIe8Ib+AalLpiN5hpmL6tfVIjH2/wE7DoNXWwt/p/Y5olRC49pmm9qMI6yMrfGIrRe3ZRS8P2AAMj95AI0/fQiNPzoVs7/3dfgAZl95JvyaarjX/hp+bQ0SPzg1vwHnuU2hMp/k2lLoelZqZIxhOG/lQNvCy/uDjKztjPl8YXnw6JeQGnMIEiceBH/th4X1J31uAkY+UAUvl4MzeYypZziRnmsY/3BqqLHeGH84f3jL1PNe++yCOhLZPZLMNNjBpKkEkbIDHuHEd94f0N+UH0ZSXA6gaVl7gFhHrwkdgrCVKW1nhtDqqYlOnFsv8NmWpGzlyiBEsgY6fx/YSsSSFI22s1ck70zbSG+KrcGImpCUD3dWPtoY6zdu81viG9OAoUO2Wa8YPC+HxitOQ+LykwPrE+1R2p5X4jGqHox70iHsb8lTDgOAogXMNf5qBeIxB8lTD9/mt8yjL8FrqEPjWROLtDdFUbqKds5Kt+D+6LT8Qshfwonvn1KSvzyVbYnHHLi/XAEASIzfu7A+8+hLcOe9gNTZE8vUMkVRKJXbOdtGZVMkcgeVuIl/sU/kOlZalxh52MopxU7jFsWDNspE/0B0MZHYthD/7bWfhpYJDDVQ8wuJqQgXMeww54TK8rZmLHRbIqEGfMW3N/eU09AvtEyOHiNj9hE49pYWs0yv0Qaj9lw5ek/4H2+C+8sVaP3Levxo7Gj85G9vIrX4dbhHjkFy2n7Amg35ttAZCMT4InXtbxCPxZA85TD4n2wwbR8xCOnfPAMv58Odc4HZP436rrWMsi01VOKmxjnEtISFRn0L7qPAtaL3vigqmzHjoQTKcEM9CC8jeR90ZnIU5d1VLKmcK8O1U/J+LnXkOUPlds6KonSJ2e3j140LX8N/vfYmsrkc3CPHYPZE2Zz9eCwG91ftX99HGuew9G+egfvLFUidMb74jVaUPoZ2zorSB5k9eQyuXrQK2Vy7mY6wYwbMOLj7qxXAlhYkvnoAMo+9DPeRF5E6YzySpx6upjKKEpHK7ZwlkkzAiIGJmo4SMSiRcWyxNUXojGJJOFE8t6uYFHo0KptGqRJ51qFRpyQyOeDpLJGybWQ7bOUNzZmWSKB1Uk9nEsEc8F+n54q2n4ugpeeQM5ypNcux4XmpOjP/pULHnPVyuOalPyJxzP7AziYS3CdBjjTdpb+xCYmjxwItrXAfeh5zHn8Z2bYcUqePR/Lrh+XlVSa62GkN9/+OdI6LBTOU4XDvDsZzPQAnfUvgpGzOW9tWGqZI3qEdZQRDgdZEGR7j1nPvMvpscAYjNqYsW68vEj1g0EdRlO4kM/8luA+/CPeIfbHxijORmj4O7vyXkHniFat6EicchJqqGLJtOdRUxQpf1IqiREc7Z0XpQ3R0zKkTDsSV40cDABLH7F/ooNP3LpbX9fALhY4525ZD+oFnS9VsRelz9AAtqQhESTfG1WMbyRhF4i6WUUhYWyi2XsASyUokt1OJmDEPoX7NxIOaCngBKTtQPY2I7fqQQkDKlpiN2OIwsimXhlJybmOdS9/UBMTbYTukvnUsEjOnwemYs19bi+TYvYAdt4NXXVVIJRk437Rdu22P9L2L4T70PFIXTEHynCPz/7/zaWDoICRmHh1MDckcRyBdY4x4h1MTnzLhRHlWuLSS3PPEDrkxUdl0PTeswd0XrCRNn0uyTIeVOspHSXdrOzwnqZMrH+UacuevFEOZDL2jc1YURYR78THsb8kLpsIfNID9vYOOjrijYwaQ/7euDu6NjwEAZrvnFqW9itJX0c5ZURQrPC8X6Jg7SMw8uvC7oijRcHzfr8hZD97HvzP/kUTKcXIEjaakUZCc/GoblWdb3jZ6sLN9SaRp2/SbouhPRpKjUMmsipHSYowkzrXHYyRCidlId8qpTDsdzsyGwnmD0/u3LdycxNm4kSy3e2RToxdiiAJuGIGanZBrEvDQpp7fltH0bBR3sSJiOdmZIWBIUiz50tY4h7nO9HqCeJ4HTJQGMilGOagvO7nWhVS49DmRmClRogyV2Q7zSYYRbP3RBcS3O7HL21I0IExRFEVRehjaOSuKoihKD6Nyx5xtzUNotGmT8XEGMVdAK4l8pHLdEOLpTHyC2fZQJCYglBomStjGM5yTcwLRsaQOTsqWpLUU+fwKUtlRONMSLm0eXc1JgQx+saTSCLBSNjeUIZGyaSpEet1b6DKRpzvKkmXWU5zK4IF7gbaXXn+71Kfc+aA+5bayo7N2jfkPlXypdM9FVlNszDo+C8m+2DSR5PzT9xqXGtLS25pK2aHDgZaGPgFs19tuK3nfRpGybSPAI1D+N5OiKIqiKAG0c1YURVGUHkbvkLUl0Xd0mcjazkefoPGexYjHHSRPOMiU6ZeXr9P3LYPX0A/urOkAAJ9GDNuah3Dtj+LdykVad9YW29RtHJzPL+cFzEnWttj6FAckwjL9TUoidK2jsml0r0jKJkM0NFqbDumsb0lcPKEAACAASURBVI/upUMNg5hhB3rdSMpKh8izPo1qprItve+qmJSIjkAiDES4R4jipvcm3S8Txc0NfYhMYji4aG3JsAwtQ66FP6C/Wc9FudNI7HXrQtfTKH1fMoTVQbEMRii270PbKG7JkJ6tnF4k9MsZQDzuwL17MdK/eSawPn3fMrj3LkE8rqdJURRF6T4q98u5iCTPmgQAcO/O+wonTz280DGnzpmExMXHlrN5iqIoSh+jcjtniYwgiaxslwiTZ04Emlvh/nIF5jzwHLJtHlLnTEJyxgT4gchTgRwcZXI9134KJ2WHRWtz9dn6kXOI5B9BRHdcIHfStJIgy5w5CYWT+UodrR1Fyuaisun1p/U3kyhbGnHbROTmzUTW3pxf77cYCdwh59ih+6wh56/emFAEooXJYfhVZNvAsTIR1zSim4lkpucvMJgS63yGQ8AghUBTWFJ8bqaHJPUst76NkbIlJjrBxpnlOjp7hCwzsyICJjRrPiX7NeXpuXVoNHv7bn1u1odkqM7WSEQiZdvut1hR1rYzcSxRvZaQPOUw1FTFkW3zUFMdR3LGhHI3SVEURemDaOdMSD/wbL5jrooj2+ohfd+ycjdJURRF6YNUrqxNkURNU2g04nZ5g5HMbQvg/moFUhdORfLcyUjfvxzuzU8A/eqRuOL0zvdla0ISRU6pI962YTKbbRRhsQwAJH7aHJ5ApuYiwLmoVkYeDUSgCryVraFSczZcNhX5OxdJyi54aAPAxi2FRX99ftlvIpHdzUTipvtvCPcdD0jZREp1qLc2Me4JyNGBIRlyzQXPBo2U9qk0Tc8luS8CkdU0Yp0u0/qp2RA9FkEUtOgdIZG76fXkIue5YR/b1IYk6pser0/PQ0c9trNUJD7bErhz2UyGbSRDipL3cLFm00Sgd3TOEcnctgDuzU8UOmYASHxjGgDkO+j6eiS+c0I5m6goiqL0IbRzBuDlckhdfAySZx4RWN/RQXslsGZTFEVRFI6+kzKSk184cwcqoXKGCpJO2zZVmQSb6G7biELbqHMqsXGGJNy2nCTOSXW2Pt6MUYnf0D90fSQCUjOR2ag0SY+9vp6ph5EmqZEIlbipfE0lWhqVTaXstSZa11+Tl7v9LWSfNeacxQYRSbPBLDtU4h5EonlpFDdNPdmPrKfpBqmUyhmVUCRpP2lkMj3fJEo59vY7pvxf/2XKUEl/j+1NmT12NcvbDTXl6XuBMxWhSKRSWg8dsmB9oplz1cxJ4qYe51MTrR0Y6uGuS1h9tlHWxRraszUwsa0zwpCFpoxUFEVRlF6Kds6KoiiK0sOo3DFnWymb3ZacgjhXhqlTUibK5Peu+nVLIhOLlX6Nmh1w9QTkaLKeMx6RRG5TJHbdJTAJCHhZU7/29etNmc1GUg5EwdJ6qJEEPedtTNQ3lbJp/XQ5JCo7v2zamduUr99vIue7iab3JNHONKKbMS2hvtw0faFPjU1MafjcMAV3b9LrzJmE0PX0+nz0sVn96KrC8jNLdyosb2w1RiUTvvS3wvKgs0ib6bXi0k1KCNzvjOkO5/vMDSXR8ynwxA4YsxT7+eB8/G3laNt3aZT1FNt3paaMVBRFUZTej3bOiqL0SdIrVuEX/3429Lf/Xr0a176+KvQ3RekOKlfWjiKP0MjXzZtDy/v9SURvlSBaW2I2YCt9SCTpsDZwcjQrTTPlJdI0Xc9J3Jz0xsnXVL6k8h9jKsJCjoVL+xeFgM8yidBOzbkf8VgMyQumAhtMlDAGDkD6zoXwcjm4s88MbxuVslsFaR85g5F1m8zyp6a897GpJ7s2f11aN4WPC1TVmbZUDzbLVduZ5RiVvhmTGKfBRKb7NN1ktZFefYcZTpGY3HD3Akmb6bz/UWH5DyuHAQDW/Ls/7vnXM3hlTRW+3HAEmtvl5T81rcCfmlZhxk7j8dyfd8a0f5htnT13N20mqra1VCq5l+kzwc5CIM8Q95yx0jeJyqYpRjuTuCXmG7bR2rQ8leSj+FdHMQyxldZLgH45K0qRicdicG9bgPSdCwPr03cuhHvbAsRLnWxDEXHRbgfhy/0m4o0tS/HG5uUAOjrmZZix03icvtPhZW6h0pep3C9nRemhJC+YCgBwb1sAtLQgOWOCSUH6jWlIXjAVFWku0Av5ckPeeOiNLUvxhy0rkIOHL9ZPwOk7HVrmlil9ncrtnC09a52t/HRTN8xHPB5D8nTy13G7XJS+ayG8+nq47ZadPo3KjNLOYtHZpHjO+CRKyjUmBZ11PRRJmkgKdy65bWm6QVo8vBZrfGroQCX61lYkz54I5Dy4dyzEnPuX51OQXjQVyXMn5Y0mPMZghDEeQQuJ1qZS9gYqX5v1uY+NxN36gdl2/T9NtPHL/9oBAPDAP81xVDnmTJ23h6ljt+3WFZaH7mTW04SFsRpzPR1qZBEPj2r364h8yZlpSBDNZDDH5eXMclXMwX4DJhQ65hjiOHTwRAyuIee4nsjvnc2U+Ky2ces5ExJ6L7OpU2kbLKVvSlejtbnjkBgYSVK32r7LJO2R5F+QyOkldo7ss/paPB6D+7P5SN/9dGB9+q6FcG9/SqVHJTLJcyebFKRVcSTPm1LuJikhrN60rNAx5+DhtY2ajU4pP322B0pcfCxSl0yHe/vCQgfd0TGnLjoKiUuOK3MLlUonfc8ik4K0zdvmD0Gl/KzetAyvb16KMQ0Tcd6OCYztPxGvblqKu/+5stxNU/o4lStrS+QlJtq1Y33iwqOApma4ty/EnHsWI9vqIXXRUUiev9WYYCnShNmmV+Pa05m0wsk5tpHgrIzERILGBDIlJ0fT9QE5ndmXgIDncouJrA54PdtCzwnxyvaHDkbm5sfh3rEQqW8ejcRFX0Hm9t/DveVJoKEBiVnT4VNvbXoOqawZSPto5GtsJu3fZO5r/1OznkrZ694x4vOyfxjTjf95O2/MsWrTPLMfch3+3PT1wvKle+xQWD7U/7CwPKLeyL/VA4h83UCetzoicdPrSVNMkmU/zknBTOS2z8iU1PRlR+OVPXp83mDk6hWr8frmVZi566G4YNex6F+zBsA+uPnvTfjZ35/FTqM2Y/aE0XD22tfUU80cCxd9zUnWXHk2fSgpQw1pWClZ4EkvMRAKQyLzFisVo60MzrWHawMH185SmBkxVG7nXCSS507GnHvzHXNNdRzJ86eWu0lKhZO5+XG4P5uP1CXTkehIQXrRV4C6WrhzHwYAzP7BKeVsogLA8/32jvngwPqL9xiHobu2aDY6paz0+c45fc+iQsecbfWQvmuhdtBKJDwvl++YLz428PWbmDW98LtSfpJH7ItVK4aH/jZ7wuhubo2iBKnczlkiidQynsXt5TM3zs9Lj5edgMSs6cjc8BjcufOAhgbMvvLMbcpvs98ipRhjpXKJ3BxWfxTjE9tJ9oH6o6RoYyRr2yheps3Uc7kUhiQ0zd5Vjefl9wNsJbPWYPZV5+aXOZmSyppxxkOZypHE5zq3ySxn15lj/OcngwvLv3nH7PfVDfe3N4V4chNWrr+xsLzLv64sLO/cb2BheRAxOKnabPbvZ8lMCdpebsjC1uiBizqmtws5l/4I0wlXHzemsHzAvu+TfZGhhl33MLsaaST9wPAFMctwJM9ZNWOuQWGitZ2PiRHKB8YnHLUkknzYdmZ5iLnmfIQ2c3/ZvDMkUdO2qWopth7dkntHYrrEGtuQZ7XEEnflds4Rydw4H+51jxQ6ZgCFIDB37jz4tTVIfO/rn1WFolQ0uVwLzMypjpdRLOT/Oby5eRn2aZjQnc1TtiJ13SP56Z8nH7zNb+k7noJXVwf3suLkElbKT5+N1va8HFLfOb7QMXeQuOQ4pC47UaVHpdfjOIDvZ2E6Yr99OQczGzy/7Dh2AXhK8YnHY3DnPoz0PYsC69N3PAX3VnWe621U7pezpZdtID1aNour2mXrMFOBgKS99b5s2xNFQrGVlcPq4dpF5RnqZSup2zZqkoM9BwI/ZQ6mnYHrbJveTwI9FjqcQuHMI6JA5EjfM8utW4xk+e8tRop9ts282H3fQ96exW//t2MZMLYt+d/ejW3Au82PAQCO3/LVQh1fIPvxs0waxIBkykisUYKvAj7SjJxKjIRyo4w/Nj5notcD14caD9EI7Sj3OydlByK6SfvJEIDz8VokTz0M2LwF7u1PAes3I3nSIUg//ALcXz+D1GmHI3H2RGBde7rSQDpIRr6W0Nl7VnJMEiTlJfuSmI1Icgxw73AujWcJqNzOWVGUiHS8XGin3EGwk25qeR/1tTt2U7sUjuT5U4F1m+D+9jnMmfdC3nnutMORPOVQtYTtZVRu5yz5CyZKNhFJwFaUL9FiEXZckq9cro0ctnZ8kuTwXBkOzkI0zmxrq3hwcPcLZzNK8QX3pmRbLkiuigQNxU2ZWNycZ7ppfWzI1jtB0Nw0tCGIx6pR3R4wFchPFrfsErivXIklLIVTWqgjLHPvOzSoi3xhOuQZ9pn3iyMJ3syFf/0GkNw7VBWpM2pM8uxJhY65pjqO5AXtznPcFz6rVnC+AZ0EUtFzEyVIS+K7QLG1DZZsS9/bXHlJUG8J0EEKRemzxBD+1UzJd94NtZ/rniYpnZL+9QrjPNfqIX2f2o32RrRzVhRFqRAyty2Ae/9ypM48As3zrkDqnElw712iHXQvpHJlbYl8wckRtoP6EsnF1g6TwgUcSOhMWrENSLMNzLDN0mNr8UnlP24utCCjVUCyrCUS56aNZnntmtBt/cFECqaSqHWAHz32CAEztJ5aI2U6/Ux7agYa+8xdG4zF5n7O2MLyv5zF8P0W5LVgLlitCkAbBmbj2LPuMADA7v2JZWc/YsFJs0zF6XNIrnM8wrxSGiBFs8zR+czk+jjk+vi0THW4LOvXc0M39N4hdq+cZB04LmY9B71/qUQ/YhgyP30IjTc/UTC48QEkkjOAIYPgzn0Y/g4jwqd/SnwXIHgfdEjrkjnRtlbBkuECSbCX5N3LDTtw8r8g62EpqNzOWVGUSPg+4Di18P3OXjJV8LmOSOk2vFwOjd8/GYnzg9nNOqaDtun0z16Fds6K0keJxerg+83IfzV3fKZ1fAk77evaAFRhr/rxZWihQnG/d3J+Yf2GbX5LzJoOf+Cgbm6RUkp6R+cskT64zE+0DJfoXCJrcFK5RDKWyKOSCOww+06OKBHuIss+QYS2KGqeiVimkdt0X/QLj0qZ5Bw7W0yGp9if/1JY9p4xy/4Wc22rxu1i1n9hlKl/xAjSNkFEN/f1Sa8/zaRG50s3h0eVOuScxAaYe7BmmKlnl+3XFZYv/ryRZf/+xn54Y8tS9KvJz/Xdkn0X8Vg+etnLbcQ+/fIy9ptblmG7hudw2sjDAQC7Djf11Qwlbakz18EJSNlkmZu3TiVreg7IM+Z89IlZ/wEZghjQzyyP2tVUSecq02e72nLoiJb3mHeHBMmQGIXuixxL4Li4Z4sMBzgkI59PrwuXkY21vfS2/V3wjnDWrw+tLpCZrVjDgrYeE4Eshky2L0op/B4YekfnrCiKNT5y+HK/iXg/vhmbW95Fv5qdQHxM4Pt+wbIz55fAQEVRFBbtnBWljzK6YSIA4P3mJ9FQm/963tj8HgCgKj6w0DHv3e8InLFTz+icG+94CvGYg+QxY7f5LX3fUniDBqq/tNIrqNzOOUrmJ2oqsIkksacRoFSObDCyWUCKkUTuRUnsLamHk3RsiBK5zZkXSKRsiTWnJKMORWDu4HxqZNnc838tLP9xQf/C8pomI/kdvO7twnJdDZHKqUUilRrZqFLSCPrkkUtIjTOoNEzlSIdkIkIDiZYmVcZbTKUD2kzaynFxk4VpaG0+i9HU9UcX1rXmTC37DDLPxl4jjYzcMNLIzvHtSGamemKCQaLI6bXya8h6Gt1dzQwLbSYZs975APENm+H+9jnk3vqokNYxtl0dMgteRePjLyM1cxqcT/JtDWRm4iTcCLCZqCSyrMTKVTIkwg0ZtJhrHnjfEYtVn5P3bQxhOGm3meyfvlfJ8+xw9rq2Q4eSGSPcNbGdwdKZXXIRqdzOWVGKzM1/fx4xJ4aZux+4zW/XvPAGvJyPzLF7laFlSgfJkw4BALi/fQ5APu9yR8fceOwBSF54VDmbpyhFQztnRWkn5sRw09vPAwBO3uGIwvprXngD6ZWrkTxkdLmaphCSJx2C3CdbkFryOq5ZvhpZL4fGYw9AYtq2UreiVCqV2znbJrqm0s4GMxXBee9DU+YjI3dSz2LsRKJydzDLAYlbgsS8g5NrskwkoU20tm3mLI7AtozfNWc2QmVqKttRmY+Tu+NMVLYtNHq12ez37J0PRVsuhpvefg7rszU4beTh+PV7z+D+d1fjx/vui+/uORrYFC4XBuRoW7mLnjfqj0yvSz2RZUn7OZyhpg30ivavMdvuPSR/7++5nkRBE2oGmHNTPdy0MT7EtMUZYCLKnUEkarofiTSnMjw9PiKr+jQynT6rAUnUrE9MHlPomGuqYkiekFc7wrLMFZU4M+uDIhmmoufBY+qhzwc3XMPJ4/TccnV2NdpYMpRGrwMdyiD41eHrA9galdi+1yR5E7j2lNhbu3I7Z0UpAefvkk9kf9s7y/Gb955Fm+/hx/vuix+M1q/mnsScJavyHXM8hmxbDpnHXkbiqweUu1mKUjTUWxtA4z2Lkf7FktDf0r99Do13PNXNLVLKyfm7HIwqJ44230OVE9eOuYeRfuh5NC56DY2T98Pm1NlIHX8g3EdeROaxl8vdNEUpGpX75Wyb6s9nIkA/WIv4lma4D66E/+46zJ4yBgDg1MSQ+f1raHzyFaRmTADWtk+kH0JceKgUJzE5kHh0UyQRiWGSTikSnXP7pNjK9gHpmywHpDfGB5eLZA3I3eHH5Q8wUdnxvU2O4n0//icA4Jrn30Cb76EmFkM25+H6j/+AxFH75QttT3y2o/igB04hNVQh0eDk/qJSuT9woFnvkNkGBC4OvqraDA3E6vMSd9V2JOKbXAeHRFzHiJSNAUTW7kcjx+tDl/1+ZFtyTAFDDHq/0Ohuak4yamek71wI98GVSJ01Ackz8nEBySO/CIwYBPf2hfD32gWJ734tvy2N0C6FBEnvd05epkMx1FzFdtYCB63fC7+PivZ8d9RjmWuAdS6j20rkZduZLJJ3kATJfksQuV25nXMRSX4tL2W6D64EAMyeMqbQMTcevT+Sp6t1YV/hmuffwH+sXI3E/qPxo7Gj8Z+vrkbjglcBwHTQStnwcjmkvjENyRPHBdYnz8v7TbeVeHqLonQX2jm3k/zawfA3tKDxqVdx9aLX8xGgR++PxFf0hdxX6OiYrzpkNH6wT17K/tHY0agaXlXooK86+PPlbGKfp/Gir+QX1q7b5rfkeVOQ21XzTiu9g8rtnG1TG3LRjkRCS3x1/0LHTCNA2WhTCle/ZPK7JPpRErXYsRzl60HkBU6kNBqtzURlBiK0A1IQkwKSi9wWGIywKSPpcRGZzR/9BbN+71eQ+vJIJC+YGjgPyYZD4IwaCc/LIbcb8W6m0fo0ijcX7oMdQJJSs42YNNQRiZtIvX7OREgH/KypaQk5zz45t7H2GQlO1qzzm4iXdQ1pI5Wyt6PmK+QckGfDb6CR22ZbehxgUjcGrmG9qSc3cgdTZJgx9Q7USSVUWw9tCRJvZTLE5axda9bTyHMq+w4mZin0GeKk8igyuK0UayOJc/XRY2oTmK/YttFW7i4F6q1dWjILXg1GgD7+MhLHagRoX6HwVRZCYmbeRYvxK1MURSkqGq3dTvrBlWh84hU0HrM/tvz0AqSOGwf30ZeQeVwjQBVF6RqpufOQuf6R0N8yN85HivlNUfrOlzON4qXy35D+SN+3DO4DzyJ1ziQkZ+TN/pNjdgeGD4J759PAbjsi8a2v5qvhvLUlcrQkHSMX8cwZHoTVaRvhaOuhzcnUXBpHrh4K68XN1EORDCkQAkYVJO1jwIuZwqSeDEjZ1CeYSTHoSK6/R9bTaHAqcZOmOeTYfUbKRgtJHxhm3rLJGJM4VcTghBjxcFHZNPI9MPxDnpOAnzY9N4GIYua+oOu5tIk0ArwEHtoBOPObwLU15z7ueXCvexhobUXylEMK69P3LYd72wKkvjEtaCpDz5WtfM2lVLXxyv6s9WHvF7pMjZIC7y5OnrfMOxDWlq3LRJHqJXVKfLyLRN/pnD8DL5cLdMwdJM85Mv+7pxGgiqLYk/jmMQAA94b5QFMTkuccifS9i+He+XQ+6vyCqdC3ixKGds4AGs+exP6WPOdI+COGdWNrFEXpTdAOes7PlyDb6hU6ZkXh6B2dMzeZnUsxRmWWgOGFkYX8ocZsgpo+FM1b1da7VSLddKznZBhJujMuEpyrJyBfCyKQJdA6ObMRTsrmyjDnOyBBc9G91GCGkbIDBMxvLCU3Wr/TeXmfHKNDI4DJPR6Q02u3PUYH6812dD31l68nEdHU57ueMRihBj0BgxFGyuauJ3c+qpihhlLTxejhxDePwZxbn0C21UNNdRyJmdPMuebOQxT/eM7khBs+qmL878PKcJK5JHWvbUpaWyMmST0UyTtWInGXYH69BoQpiqKUmMwtpmPOtnrI3P77cjdJ6eFo56woilJCMrc8AfeG+UhddBSal1+L1EVHwb3lSe2glc+kcmVtIr8G0srRZSqzUYl7kDFRoKn+AgYjNApV4qFsayRCsZWAJFJPZ3Vw9XFDAayUzsz8tZXPOOmNC9amkl+gPLMBN9whuCYO3ZZEpPoN/dEptr68Etkv4ElOorVp2kpy/wauEPW5bj9vDvF8DgxA0OeBRmhTgxFqPEIjjaNI2Zw/Oj1WLmq+FHAR9xTmPZK56+l8x3z5SUhcOBU+kPf+bmiAO3ceUFeH2VedY9ceybNlS5b4frPycft+i5VOURLpbSuJS95Z3LbcjBhuW8k7PwKV2zkriqL0cLxcLt8xf+cEYPPmwvrEJccVfleUMLRzVhRFKRFue4asMDo6aHWdU8Ko2M7ZIRP3nY8+MT+s22CWaWTqyO0Li4Hoa+rFW0p5+bOQRAByEkpnf3mXOK1Zp5HjQNBYgUsHSbGN7uakbIZA+sVWIqfRaG0qrXoCuYuD1OlTqZzu1zZiVBAqQiVmpx9jzNERdUsjrmkkLueVzQ0XcQYj3PVhpUBGyqblSy1lExyJARATtewPIu+aAcSTnJ4TLuUpN1wTY2R/Kk1zPveBZ4s5/1RipkMe7esDRkyR0qZamnvYDv9I3k302taR54CT2aOYn1jSawLCGm//PdJ3Lgz9Lf3zxWqTpyiKolQMvaZzjsdicG9bgPT9ywLr0z9fDPeuRYjHe82hKoqidAup//0dMnPnhf6W+envkPrPX3dzi/oOFStrB/DakDx3EuB7cG9fCHg5JE8bj/SvVsC9ZzFS5x6JxLenh29rm7rRFolkbSvddFanbZSibUQxR0DaY6KyqcLJRXpzkh9Xnsp8krSS3HllJG6/X//w8rZw0cZU7raV7ujx5ogESeVpzjilXfmkknVgOyqB0utJ66BmIxQmolx0f9vOduhObA0vJKYynPGI7XMQuKe4WRSCe4oM41TlPLg/fQhOWysS50/JN9fzkLlxPhqvewSNPzzFvDejmIRwSN7JWWaIiMKtp1K2aKZEBEMVS3pH59xO8rwpwJYWuPcvx5zfPItsm4fUuUciOWOiBl0oiqJY0vFR4173CNDahsTMacjcOB/udY8g9Z3jMfvyk8vcwt5Lr+qcASB52vhCx1xTHUdyxsRyN0lRFKVioR30nNt/j2xrG1LfOR6Jb0/Xj54SUrGdc8C7d9h2hcXML5YVOuZsq4f0oy8j8a2vwu/PSJMSj2kq10gmy3c1snrrMhJpJWxftp7cHNxxiM4f479L5TnOkMKjkiyR9iRB2R4jywYgZh3kGFmP5lLIqVTupMfV0myWJSlDyfE6ZB4t1q0PKQxgIDHgaY+0DZyltcRne/0WU/cIk07T351EAtPnkPOCrhVI1vQ+4rzMaRmntJJiYIiDw3a/nO87NU4KmLdw+2Xua0maSNYEKBa+vv2cJy4+FnNuehzZ1jbUVFfxw4Sh7bU0JKH3umToQyKnS1L0liI9ZQR6wCBO8cjcOB/uzU8gdfExaHrxp0hdehzc6x9F5qbHyt00RVGUiiVz02OFjjnb2obMjfPL3aReT8V+OW9NYRzk4mOQ+MY0AEDiW18FALjXPwq/thaJ755UziYqiqJUHJmbHoN7/aNIzZqOxDePQeb2BfkxaACzf3xmmVvXe6nczplGvg4diraaWjRecRpmX/a1wDjI7CtnwK+rg5fzOzcKkUi3thGJ3LZchKGtrN0ZUSSZKOkxuZR1nPQW4yQoxnObEjBo4Dy6qZwXfk4CkdJEXvZrGROPEkD35UgkbnIfpa6+H/FYDMkLjwI++ZRsG0f6vmXwcjm4Pz7d1L+5XbZ+8U+FdWsWGYl1/QZjNrHT3v8oLNceb6K7qcmGQ0wwAleKSt/E1ALM+Q5I2VXhqS/9OjtTFltYD23LaOegLE9lZIHJjcSHnj5PEm9t7hmikOuV+Z8H8x3zZSciceFRAIDEZV8DYnG4P30Ifn09Et8/pb1dEYbwuPWWPtiBPAtkaCLwDNP70XbGAKXEqUort3PeCvdHp+UXQi5a4vKTe8Y0DEUpIfFYDO6tCwAAyRPGFdan71sG994lSJ0zqdM6/uvN1xB3Yvje3vtu89s1K1fD832kj/9S8Rqt9Gi8XC7fMV9yHNBk/oBKXHo8AKDNU2/wUtFrOmdF6esk279s3FsXAFuakDzjCKR/uRzuL5Yhdc4kJGdM6DS6Nu7EcO0fXgMAXPi5gwvrr1m5Gv/x3GpcdejoUjVf6YG43zmB/S1x6fHwqSWpUlQqt3O2jazjZMEoE8lto7659th6dHfW5iwTaSqpO4oRCyuhMynuuDLseiLnUbmQkwU5EwcK/cs/J4gA7UYCUhxNW8htkPOR71s6CAAAIABJREFUPH8q4APubQsw59fPINvqIXXekUie1f7VTI7Lee8jAEDTG8aP/qiBU/Hh5xpw7R+ewV/WDMJx2x+BRz9cjnkfrMZle47D2QMPAD4ikvnuu5r20nNGfbapPzONKF9v9uts2mTWk2vrDzHe9/5gEzHuUP9qeg6ieG7TCG1bIx96D9Jjp88T5zFeT3zLuUhsbj0nZdPnJpAulUTaU0k8UCf1Bie5Bzo8tblZKhxc1DT3jFmmrXU2mBkGzsdrzQ8t5HoOaDDLZHaP30DWUyTmUVz5IlH+N5CiKEUlecFUzLl7IbKt7XP9z+pczqactfOhAIC7/7UU8z9cgTbfw2V7jsOsPQ8oRXMVRQlBB2IVpZeRvtN0zNlWD+lfLLGu46ydD0WVE0eb76HKiWvHrFQEjXc8hfRd4QmQMrf/Hqlbn+zmFnWdyv1y5mQELoUZZ+IQJYJZUkYiiUgkek5m6cyEhCsr8fm2hYvQpnCp7KgMR6TPgEkI3ZbKUZyfdsA3mzEn4bal54TKnZxPdamhUi9ps0POg7/DCGSuexjubQuQuvQ4JL711cI0GAwaiMSs6f+/vTOPl6I68/6vurmXXQFRcY9xjGaiiKigIuKGGpeooyGaZUzMYtSJmWzmVfra9869SPzMO+/E5MXoOI7jJJNRM3E3LqAEFWRREMgyeY3BfcUgEuAudNf7R3O7noJ+7Oehqrndl9/3H8vqU6fOrTpVh/qd5/yeWLq/YEgparV5THRd9xpekpdnvfgsNoUFNAVZ9IQF3PrmAnxv7Ob55hF7RO0SaSUxSEbBRvczWCtkx1dfL28XFrxQ3t7wh0j6bh4RHTtw8l5RnWMPiv5W2RfkfbCYk8gpAosvs8SbqtAU0a34lsvIdi/q+0JZLWGZzup9t3r93yWWiGiv179YJZDt7kb+p/OAzi60nDexvL9jcwKktktO3mL6QqS/1NCujfY+TYnGHZwJITE6brgX+f/zS7R9+3zkvnYagM1r/TMZ5H94LwBg+vemVa1n1ovP4kcvLsaX95mEi/c5Fre/ugAzl88HgGiAJqQOafns8QBQGqB7CmiZdiza71qA/B1Po+2Sk9Hytyc1jOUoB2dC+gmFYrE0MH/z3JglZO7vSlaLBcOyl96B+coDJuCC3Utzzxfvcyx2G/UXzFy+HAAwAwfWoPWEpIMcoGf89zOlBEibB+ZGIgjDsFH+IRGj8F7lHKNxY4OuaFtKR5r07cUiO9c4rZjaHs85vTKV17c3dmx1U5FgjYgGFtJeuFNkeBGTtbVIbM2X2Ys0vLH0nSQRw16ERCenANQI9g3RoN1r2BC8/U55X+v1/41sJoPcp45CuC56fjL7jUb7nU+jUAyRn/nV8v5w1KiobnkfxHkyf3opau7Dvy1v3/Hg/uXthe9F1/gAsTrnq0f/sbw9/EvR+urix/4qKiSlfU1eVKL7A4sPfpKUrppPvETrv0KCllMDsWhqMU1hygHgna6R25vrjEXWi2mNWGS3ZjBjMfRxTh0E778fbb/2Znl70KmtpTwLA7LofPK6qJ17jIm2ByuytsVnX+kL2V3TcaLklzMhpEz+3Inqby2fOQ4AGkYWJDsu7T+dWx6YuzcV0H7bnFJK4QaC0dqEkD7jnrd+jfvefrLib7PfnYeZy5Zv5xaRRqf9p3ORv+0JtH1hCjofuAZtX5iC/C2z0X7bnL5umovG/XLW5CghZce8iUWEa+iVeqXsJGUZS+ShNyLR4vVaTVpL4tXtvTYSqaRaIrcVpOtQsG5d9INFUg6Uvz12AoPErdQTKFH/YVNKUyVespXNOAJp/CGuYfDGW1GhdzYbNkh/8QP3jn4fIQxAhkcpV2PGDcpqAHn+8nkAvPxsVM/tL23Aqs4CVnU9iYFNv8Og5t0AAIeum4pXOhfila5ncMDwo7HqpZJpxNj3hGmJiOiXUnasp8WeA8VgxLJaQ0tnaelrlr4v65F9U0rTcr+crtOeXfmsiHoCeazcFn7TsXS8sm/03lPpXy2fB83QQ5Oyve8pLTpatLf9l4tKA/MVZyH3lVMRAsh9+3xg1IhSso4hQ+LJOizvWO+0Rko07uBMCGl49h90DABgVVcpGnxQ827lgXnfgcfgax+Z0JfNIw1GoVAsDcyXfjI239+bf9oSFFkvcHAmhPQp+w86Bm8UX0BXzzvo6nkXaxFi34HHYN9BRwNonJcp6Xvyl5+p/tY7QDdKzETjDs6anCalhlg6NXGs5tEqo/7ej6IjYzLPqJHRfinjeA0JLBKzPFZKSZrHdKU6kyz61/BKOJqHryEtZ7iLiAaW0d0FxVTEgmY8IpEyoixvMbPJCElRSx+YFqEiuUspUxh/9Dz0m/L2y0tL0wcF4Sm+//iXy9vNn/x4dJqh0v+5et8NRRRvMDSKiB3UHEXi7zEwqnPvzHF4cc29AIrIIItjhpeCd4YNXB3VPyCSxGP3X5OdiwbJUqJNZcXuvzjvJiELx3zFhUGKJllryPJDousWFiqnzkQsWltEg2tmI4p5R+wZaqpsFNT7HgyGifvgfY9574NWp2yXvAay7bKPNCmmNdp5tfemJbo/JRgQRgjpc/688fcofSVnUEQBv91QOUiMkB2Fxv1yJoT0C1aufxJrOn+PkYM+jlGDP47BXe/hNxvmbf6VuaPJjkn/GJylnCaknUBbYC6QBgzBS29E9awWkaHDRT37R1JJuKciZXnTPmptE6nQsEFEngsP45gxRy+1kK+9kYkWyUqVkaoblcTrl8fK+pV0k5rUaJG7FWIezdIPXPYFxYMihiKtxjzGZfSrIunGopmXrypvPzQ7SvH4oxdKfeqDIDKV+Na7Hy1vX7RHdFwwZtfoPFLa0+TCQVEbw70i04c9p0bP2FXr38fNqxZjxTsLccEeU/A3Y0rOTh8dth7/9koP/uXlefhZ4QNMP3lc6YBdRF+Xhh5F5Z5brrcWfS2ITXe9Fb0vsH5DtD0omsoId98t2pbTMlq/i/VxRa6XRivqs6WkXRVIT/KgKO6RjO5WTYZKfVmdzrOYL3lXj8SmKWXqS2V1hGyD9h5OO0Xvh+1PQP8YnAkhLu54/Um81FnARzZHS0vufetJFMMiLsLHat6OYljE5fsfjeNGHB/bf8m+RwMACsUNlQ4jpN/DwVnQesdTyGYyaJk2aavf2n/5DArFEK1XXdAHLSMkXTJBgJe6FgAARg0+tLz/3reexC/f+jXOH3PCdmnHZR8tDcK/XbP1b5fsezSOmFrhB0J2APrf4CzMIEIlO6GU/IJ33itvZ97fiPyjSxH+eT3+17horusHyxai9bGlaD11PPCBMHQYHUlWMjo1kQwio7KlTCVNHSyL4qu1xZOC8sOOlSSJ0IxJYuLvjrVT6JRZ5eZKuVBK2TJ6tckpQXmlb820ROyPSdNaRHehenl1dYJoc88rUX+f986eAIDdB5yMpuxKvNS1AK90L0MmMwTF4gYsfX8jxg87ASOCKeh59cXycc0ysle5h9LcJ5Cey2KFQzDpE+XtQ0a9VN7+xOrIEzkYHUUDB3tHHtqhNEXRZFgtct8SiS2RHuSrXilvFxZGXt+b3o6mMpr2iu5P5uio/8YiiYcY0hNKknjYa/XI92OgPN/VpF5Nvk4rJa3pHeE0a9KwpH3UzqU822nR/wbnBOSmHg4AaH10KYrrN+GaSWNx3fwV+IenV6D11PGYfsq4Pm4hIenRNKA0aPYU1qBYKA1G44edgMOHT+nLZhFCwMF5K+QA/YNnfoPuQpEDM+m3NA0YiZ5CJB1zYP5w/mH2MmQzQRSkJuiYvQyFYoi2o5lSkySnfwzOSfyrpdS4WSKafvI4XDfneXQXimjOZpA764iovCUqO4mMIw1PpMQtTSBkGUk1E5Jap8dLy2s8JrFpEp5mbKJEZUspWzODsJhEaCkALVKpNMtBFH0fk4M3iah82Tct1t3KtR2wRyS5fnRYdA0HrRmJjV29cnIAIMRrPU9i6q6lAbppHyGly/vgvf8ycntMFMkciD4d83yWkriILpaSbOwZkM+hdu21+6NETQcfRKs1whciE5dN7wDtK5eh660QX9zj2PL+2389H9ctW45rDj8MeCuaKgv22iOqR5O1ZT+S01de+doy3aTcF/dUVbWySd41Fm9tDYu8rJnWWNJEavtrEK1NE5IKzBADc3ehiI5HlvZ1kwhJnY1db2Jj9xsY2LQrdhrycQxs2hWPrp6L2e/Oq37wDsp3DzkMVx86DjNXPo9ZLz4LAJj14rPlgfmqw8b2cQtJf6F/fDmnyIw5z6P1saXInzgO06eMxYx5K9D6q+cAALnTx/dx6whJh0ffnYeN3W9gcPOeaBowAgAwsGlXnLDzIXh09VwAwN/jgL5sYt3y3UMOAwDMXLkYP/nTs+gJixyYSer078FZkUpCYeIRjI4iSa9bPg+tjy1F2+eOR8t5paTz+UOmIrPPCOT/49cIRg9H7tSjonqU1GqWNpj8iUeMqFyPJxLSu+Bew3JOS7Smtl9DRgnHDD2E5FdQJG6LTK1FhsciXKVXsjMq05BiMFCuW6jdL026jfkjRxJwZmxkPPLFiX8AALy5bDV2ajoe0/acHJPPTj7iJVz/3FgUwtXIHHJi1BYZdeydRpL3anAkZYcW32lZRovQzhokdy0yOeZlo0x3bYz6YGFT6Rp/6+Bx+KffrkB3sYjmTAa5KYdElQ22vBekYYiyIsEiZVueOcu2ZzWGdzWKReL2rirxtl1DM/SReFeqpET/HpydFIphaWC+cDLQFS2TaPnclPLvhPQHrj78MDy+cr+Kv33/iEMr7icR//S75eWBubtYxMxFK3H1RF43kh4cnAWtnz1e/a13gObwTMiOzT/9bjmu/+0yfOegI/DNj43HDf9vKdqfKU19cYAmadG4g7M3MnFTZaOH4pjdy9vBzsK7V0ZKixRpqq+sNyrbG5G4rYv3vQvxNc/aamYnQLyN0mvaImVX8fPdCi1q2pJKUvPc1oxNtPvWo6Tck6iRwZWLxyK6lesWGq5nbMpl3z3Lm8O/FF2rc197d3OzRJTyvpFJSLjb6Mr1Kf0+sNxbeQ280cJZg1m2No0gz1swPBPiOc/sH0WY33j/r3D9b5eh9ZTDMf2EQwH04AcTD8VOKwYhf9d8DNhnOHJ7Hx2dNmZOpPQ7iVYmNv0itrXnoyuK+g/WCI9+2WfF9Qx3iab3YlJvGmht1N4RGt53indKL4k8bokkd9K4gzMhhGxnCsViaWA+6bDYP7BaLjim/DshacDBmRBCjFx7yuHqb70DNKe+SBoEYRg2ZF8qvPvLyj9YpAmLvJwkylnKLxaZ2CJZa5LOtpoEpIU8pzCSkBJnTNrTrodE80qW3tGWFJNuqdniU6zUqdWvYYlOjp3XaeQg5f1OIXFKsw8pcfYipU6xqiFmAKJFzXtlwSTpOr0GFgmie4PVq6PtP4tEHKK/hLtEKyvCYcOjMlp/t8jaWvnOrsplxH0JXn0t2n7x1ahta0RegZEiDeUB+0TbIuVlbOqhYnud013asZby2rG1SJFrOa9CdtfzfedVoAkJIYT0Y1rvnI/2Xyyo+Fv7Lxag9c7527lFxAIHZ0II6cdkMwHyFQbo9l8sQP7O+cha1CCy3ekfc85eH2dt4b43fZh2Lk3K0hbje1OteY08qtWXhJ5IbpepOGNRvKK4mupPosrUmhzplLg1SVmNjhXlLakqtf1SupXbscjzytWoKQ+1f19LuVlcc+njjV5jEUuKPu3ay3suI7o1/3eJvMaGQOz4sU4PZW2/vJaxtKLC33u0iFofKaKaNTTPdU2ythjhyLZp7RfTFDJCe/rEgxGu3Yj8nfNReH1dPNveaeMx/aiDEayNUuFCpPgMK73LLCsrLPcnrSlIb/3atvxb02p/AvrH4EwIIUQld+rmbHuPiGx7p40vZ+Ej9QdlbUII2QHInXp4OZlPczbDgbnO6R9fzkmMLSxR2Wl5rkrZxJtSTWKRwavVsa2+ulsiDF1iHtSCcIBTs/TapGpydMxcRZGjLQwwpIbUoo21yPBAkeI1NNlcM92QxNIECrm5Vyq1SIpi+iJ2zy1of7dmKpKkP2qSryUaXOunsh5LlLVXyo7VqflKi7Z1Vf67gk0iilvYD/fS8diyeLa9ucujZD6eeWfZLu09pm1b/LQlSdJNWvIapCVf01ubEEKIl47HlqH1kaXInyCy7T1USnnJbHv1CQdnQgjpx/QOzK2nj8c1Ew8BAEyfMhbB0AHlAfrawz7Shy0klWjcwTnJwnOvXGw51oJX0pHGI5oPcSVZSYsEl6Rl4iBTHMq0gl7vW61tGrH2K9JhrA0GcweLgYlEk5q1eiwpEi31axKtN0VmJaS39wcfRNvr/hKdRl770btE+7VnJmuYRtL6aZJ+lCQaXLuWmhGOhta/LHVqfVyk3Yx5rssVEiOiPAHFoQPR9ulj0XL+MQjFua497iwEo4ejUCwiHD0qqkc+x5XwTvNZVp1o8rh8B3pX5Vjak1YaSkZrE0II8dD66WPV31o+z2x79QqjtQkhhJA6o3G/nC2ReJK0Iu68KR297bRILtXwptP0HquV1xbxW2SqJNfD64krI18tKfq8DkqaQYomrWqGJDL6XfpgNyl9WZPNZZ+tJB+KiO/grXfEduQpHb4lPKXF9QgOiiKEw4/sF5UZIqTRgtJG7VmSEehFpY9YUkNqxjOyvNdP3fSOEPdQ9jWLuY52XrWfivLi+SvuHaUJDYZU9scOLalwq5EkHawiNQcfiBSXnTJPgTCG2Umk97UYOlnaY8H7Pk8Av5wJISqt/zkP7f/1VMXfOu5fgtZ/nb2dW0TIjgEHZ0KISjaTQf5n89DxwJLY/o77lyB/zyJks/RlJunSdsN96Pi/D1T8rWPWA2j70X3buUV9Q+PK2l4ZQZPQkpzLEpHojjx2esx6ogq97U0S+e6dRqhFmjhL5KtEkyM1FC/m2FOlncsixUrpVhp2FAx92eLFvHkzEGWDdZFXdrj6A+SmHgZs6EL+7oUI1/dg+snjMOOJ5Wh9bClaTx2PlnMnAmtKvszBXpH0HkLI2kmiyyu090PrtETEy7SZXm9909SH1jedKwa08t1iikN7DoRMHZOsk6RarLTf+2xrUdmiT2cLBeR/fD/Q3YOWi08q72+f9TjyP/kV2i47I5b6NLR4wHtTAGvtrIVUrtC4gzMhZLuQO2cCwnVdaJ29DNc9sbzky3zqeEw/ZVxfN430Q3KXng4AyN/4ELCpgJYvT0X7rbOR/5dH0HbZGch97fQ+buH2gYMzIaQq008eVx6Ym7MZDsykpsgBesZts9HdU9ihBmagkQdn76LvJLKDN0JbkmTxu0UOqnYd0pCukmJJp2k51i1lGwwgVOMBJY2flLst0rcW6a1FD6vpLEWZHkVOl+3cGJmGBGvej/bLaPChQ7Zu4+AosjcYHm1fd8/C0sA8IIPuTUVct+A3yJ19FDA8MsQIY20xGIBo5iSqB7mh31ukcq2PJPFf19CmSmIe8IoJSZLoZ21/EvOmSmUtRiKm82/9fOYuPR0zbnkE3T0FNDdlkfv6JysfazGwEcjUtjHDFa3NMY9+Z1rJBDAgjBDyobTftQD5exej7dwJ2HjzZWg7dwLy9y7eKkiMkDTpuDkamLt7Cui4+ZG+btJ2pXG/nAkhNaf9rgXI3/E02s6dUPpSBsr/zd+7GNhlp1jQDiFp0HHzI8jf+BDavnZ6NOd840MAIsm7v9O4g7NF8vXKztp+b3oyrZ0SacZhSVW5rW3wmnVopPV3WzAZkkiJUKlHyoWSmBztjKaPtUdKcVKaVKTsgqGMJGZOIvu4lOtlWscoijdY/V60/dIbUZmNIlJ5TMlPOearLKXdA/ZBYcRwtF1+Jlq+cEKsaS1//RFg1xEoDBmCcJ+9SjtlP5b9W/NqtqS7lEgjFi3dpESbLtDkZcv0SMzARLTH0o8shieedLCA38/aIsVq76ZK3v0SSxS0JomLKZGOf5tTGpi/eQ5yl52JEEDu238DDBmM/A/vAZqbMf2qz1Q/r/K3mqRsSVr+204ad3AmhJhoveMpZDMZtEybtNVv7T+di8LAQchffmbFY/OXnVHa2NC51W8tl0xFOGa3VNtKSKFQLA3MV5wdG/Ry3/hU6fcaz/XWCxycCennZDMZ5De7fLWcfWR5f/tP5yJ/2xNou+KsvmoaIVuRv/Ic9bfeAXpHSNTRuIOzRV7wysKaXCNNCzSfXe8id4sPtTfFZKX9Wh1aGe16SKlLO2eS+rXyGpo3sfdY7bxaJLZFmtTQosflqTSfbYmUdMPK9zfYuLG8nTv1MKCzuzRA/6UTuTOOQMevnkP+gSVo+/wU5C6r/NUcjhwRbe8u5G7vtIbF1zpjiF63TAVodWpo8nisz0oDGEPKyFh0rxLB7p1uspzLYpahvQ9kPfJvlNd/4KCtj0tr6lCmnpW+2RJNXtamApJMR3p9/JOYXCk07uBMCDGT+9TmIK57FmHGw8+he1MRbZ+fgpaLJu8QXyGENBpcSkXIDkLuU0eV1yk3D8ig5aLJfd0kQohC4345J5GUnVJsILbDjCKDaRKwlK/T8qGutug+rQhtbxR8LdJ1JomI9JqWWFJJqucSZTRTCa18TJpWzqtJvYpJh4xIDUaUUgO23zV/88CcRfemAtrvXYSWL52CcGchI0qZd5BINWjxlNai471R7dr1UOX8BF7pmmmJVt7SFzQpO1aP87n0Pjdeqddi3tJbp3d1ifdv9b7Dk+QvSLLqRyufEvxyJmQHoP2u+cj/11Nou/A4dN71HbRdeBzyt8xG+21z+rpphJAKNO6XMyHERHlgvmgyWj59DACgZdqxwPDByN8yG+FOOyP39+f1cSsJIZLGHZwtkcwW2UGWEdJOsPYDUUak1BMSYJh1Rvp50aQpzZ+691zORflugwOLUUKSSElL27Qy2xrVDugSpEzRp15bcaxFHldNNwqVy6hSrzhUnDccvUtU487D0Hb5mchdejpC0Zdz13wCGDYcm7LZWIrBiu21yPyWCHeLVK+hXQMtyl5OQWmSu/peMHhia1i8npNIwEm8rbXzynuh+btUmjZLawpNUgsJ3ytBp5XmNgGNOzgTQkyUjUQqkLvyHIQ777wdW0MIscA5Z0IIIaTO6B9fzl65SIlSDN5bE22//W5URkSJhnKBvpAO1dR9SXxZLekjK8ms3jSV2jm9cpGlfu/90fCm8TTJ3ZqM6/w3rJoCUDHI0CRUzYtbk5Vl/UKmDgcOrNyesley8nd7I9Y1auE1Ln2tTXK6cg87t7Yl/dDyln4Ue1YMaUu1+i0kSQdpWeVSqU7tOfdOj2mkVb4WxiPb0Tq0fwzOKdJ240PIZjNoOffIrX5r/+lcFJqbkf+6LhMSQgghSaGsvQXZbAb5WQ+i/WfzYvt7fYizNQ4CIIQQQvrHl3OCiN5ARmKv34CWz08BuruRv+UxoFBEy0WT0f6fjyP/86fQ9tnJaPnbE4HOzV7bwr84lLK2ZRG91rYk6SO3tT6vj6ylfosPrsVYRavTi+nv0mRcx5TClvVbJGOv4YUW6a0ZglTrA7ILaW2PHedMs6hhidyWZQqGCGotcluLuNeixDPKNI7lvBpez20lBaf0TY+l+MyK8qa+aXj+Kt1fy7PqXRki8b53aiE1e6flakD/GJxTpuWSqcDGLuR/Ng8z7nga3ZsKpYH5M8f1ddMIIYTsAFCjVWi5aHLZ5rB5QJYDMyGEkO1G//hyTuC5HEppQkhEHXcvLA3MTVl09xTQfv8StFx8EsIhkd9wOGxYxTrdbfOmXawm6STxi9VISzqymJNIZPu9qTUlFklc80T31iNRvZWdBh9aKklLNHC1KHSL9K7Vp3nNa2h/qyYva+W1/RlFdtYiqAcPibYtJh5Q9mt9R5sy0CL65fb69eXNYPV70faatdG2eGeFo0SKz1Gjqtev4Xk3aCYokiQmR0neqxpeMxPLsTWQ1vnlXIGOWx5F/tY5aPvyKeh8vB1tXz4F+VvnoP32J/q6aYQQQnYA+seXc4p03PIo8jc9jLYvn4KWi08CgPJ/87fOAQYORO7S0/uyiYQQQvo5/WNw7okiMQMhL8m0eaqJhoyyHrEzCs3NaPv785D7yqlREvoBWeS+Nw0YOgQFBECvnJ2WxJEk5Vml81pSxFl8p5PIS0mMUCQWwwOLbOc1j9Cifi1GEhI1paJTtCoo3tCxyG1FKt0QRfcGf14jypTaFg4fHu2r5LEtygLQJWVLikZv2kev/G8y+lDKWKYstH4k02ta+r5WpyBYty7afvHV8nbhT0Libo7akDloj+hgYTwTu79J3k3VVoYYIs3VZ9VruJTExz+t9JE1jtzuH4NziuS/eW5pY+PWzkG5y8+KD+aEELIdaL1zPrKZAC2fPnar3zoeXYZCsYi2g87qg5aRWsE5Z0IIqXOymQD5O+ej/RcLYvs7Hl2G1oefozlSP6Rxv5wNUbmBkLtjQpaMppSR25q8VxASR2CQYrymKJbIY1VyrXALtQjnaqkmt8QrQcvzajJsEvOTJPK/Re5W22Ywm1Dvod7U6NgEvtVK5LZMeRr8zx+j5vz+9fJ22Fk6NvuxXaN9f/1X0fbo0bKRldurmalo0chI4BeulVEjnw2SuMVQReKd3nH7skfPULA2krWnT/prhOs6kb9zPja9tA7/66hD8YMlK9G+aAXyk8fi6nEfB9b8Japn/YZoW2Yd87az0vORJB2sZeogZvqSwK9fw2t4JOuUEn0SUyQDjTs4E0LIDkTu9PEAgNZfPYfrl/wG3cUi8pPH4prjxvZxy0gtoBZCCCENQu708WjOZNBdLKI5k+HA3I9p3C9nRb4IhbQWCD/doKsrKqPVo8kpmnxhiehLklLRIvtWkmg0Y4Aki+y1Mlq7hNyqRtCnlVrTgjda23JvvSkmTdMdBpnV4B8dvP5Gebvn6T+Vt19eHBlwknJyAAAZwElEQVTndPWU7sVHX4mk7sFDo/sTyqkded80r3Hp86xJ3Jb0jhqaNK36XSt1qtHaSj0WGVzD0heUviZ9s4PhpejrjvuXlAbmbAbdhSJmLv0dclMPLxUaKiLGmw2Bq2qfcqaErFSfxJuq1rIqQyOt51yrs8ZStoRfzoTsILTPW45ZLz5b8bcfPLsSMxav2M4tIh467l+C/D2LkD9hHP6S+zzyJ4xD66NL0TF7WV83jdSAxv1yJoS4yAYBbvjjEgDAFQdE+cp/8OxKtC9egZYJlEjrld6Bue28ibh67EEAgOlTxiIYmEHro0sBANceeFpfNpGkTOMOzlJqEGuPZTo1d2SiV1rR6rdEA1rKb6tJh1dKTwsRHS+lwFCLEpdobY7Jps3Vy6d1zy3Snuab7DVI0VBlOU0aFuddG0Xudr5WkmK//dFDserFnXDDH5/Cms5BOH+Pybjzjafx89dX4LsHj8fX9zwceE9EeXdFa/1DYR4SbIg8n2OStZC+VQMgiSZ3WyRuLULbG6Fv8buW+9MyubBEJI8aWd4sjBiGtq9MRcsXTwbefb+8/9qj90Ow23AUiiHCfSMTknC48P2XeH38LVNhlcpKY6j1Wn8ReQpkf7GsgknLACTJ+5EmJISQtPjcXpMAAP/x2lP4+esLsCks4LsHj8e3Dj68j1tGPozWL09Vf2v57PEAtoilIQ0P55wJ2cH43F6T0BRksSksYECQ5cBMSB3SuF/OivQRCk/ZmAmJtN20RFZbzuuN+tPq8UYwSqpJMd7jvGkcJeLax8pIFdbi+y3xRrhb9ku80qfXqMIkszq/eSzlhWTYLLIH7jl0PW5atRg9YQFNQRY9YQE3vrwEV43bPN88WNxDYbiTeTWK6Mbrb0fbnWIqY6SQUvffp7wZjohSGWoGQHpktXOKwBRxjer7JZb7nJasqZgihfsJc6UxkWmMvEcxaVi9zobrWW16R3lnSvk6eP3NqMxaIWvLukcK06fRUSeN9ReL/7bEkvZVkmRlCGVtQkha3LRqMWatWoQr9p+IS/Y9Bre8vAgzlj0DANEATQjpczg4E7KDMPOZFZi1agWu2H8ivr7/BHQXgK/uNxG7jFyPGctKy6jaP7V3H7eS9Ddaf/5kKWnHhZO3+q399idQKBSRv2paH7SsvmncwdkgO6gRgFL6kGnrsorkKvGmMLPI5t60iGlEXXslc29axiQL/bV2avu9Up13SsFCLVJYeqV1IeOFQvoceMTq0saqIZvtHg8EsAbFzY/BuIOPQ/ODg1AoFoG9d4vqk/7MqyJTk64lkazd/eeoyOD9o/8Z0FTZkCTcSfg8Syyyaqy804/cYhKTpE9Z6rGgHatFwnun5TQsaR0rydoi70Dw9jtRG1+IpkGCNz5Aft5yFF9bi9xpUXzDdcufRP7O+Wj7zCQE6yLpO5bjwHtPtBUdXgMTy72tgZQtadzBmRDiovWCY9Cz8t2Kv+XOOrLifkKScs3xpemStnnLETRlMP2kwzDjieVonbMMbZ+ZVDENJuHgTAjZBjoWLEc2CPCdg7aep57x6+UIX3gZrRef1ActI/VI7wDdOmcZrpu7HN2FIgfmKjTu4OyVOyzpDIMEkbhSfvOmFfNK2dXklB5x/qIi+aTlcWvZr503iQGIN9LUS1pSucVn3YtBBo+lezzyE+XNpn1Xi/aUnoNwZyEjSn/ud96Liv5P9MX95u+HYsPqgfjnF57Fe28Oxtf3nwAA2Kt7Lf5x5QrMXPE82s6dgPDlzfL3brtE9UtJdqDwgvbKhZZUknK/ZiQiPai9ErRmkJPWlEUSv2ut33nPVQWZvwDrommQcE1kYFNYW6r7+4cdgplPr0R3oeQNnjvjCITrSzkP5B0MZD/2GpJILP1IeybrwGeb65wJIW6+ceAR+NaBR2LWqkW4adViACgPzFePHYfc2Uf1cQtJvTFzcTQwdxeK6LhvcV83qa5p3C9nQkif8o0Dj0D3pixmrVqEf3lpCXrCIq4eOw7fO5RLskicmYtXon3hClw7aSyuOXYsrluwAvm7FwIAcudM6OPW1SeNOzhb5GtV7jCk+rNIPmlJlhYJSlJNEmtSFt9bvMAtbdfaqEWLeiO0NdKSspNEcWt4zUkkSaQ1bb+oJxxV2eCh1zQiEAYjMso23BBJlsWNUd3NAyKJ+MoDjygPzM2ZTDQwy+dKroiwpFx0R9Yqx6pyt+yzip+2di6tniRGOBa818orrVt863u3pewsTZ9EutFgZDRlcf1Dz6F94QrkTxyH3CfHAwBazjkS2f12Rv7nTwGDmpA7/KCoTmkkk2TVhCTJ+2I7StmSxh2cCSE1o+2+xcgUQuROH7/Vbz/8wzIUwiK+c/ARmPXis+gJi2gKMuguFvGPK1fwy5nEKBSLyJ84DtOnxPtFy2eO2/w7XcErwcGZELIV2UyA/P2l9JJygL5u/gr87z+swHcPOgI//MMy/OjF53DlARNwxQFH4t/fWoCZK54HAHScwChcUuLaE8epv/UO0Byet6ZxB2dLNK0qLzo9V71+0BY0OdgSUV0tgtnr+eqVeWthMGLxwdXaY4lG1Ugia6clg3plXA1v+ruuUqQs3llT3lV4vZRq8urxH0fxz11ofehZhOt68P3xh2DmopVof2YFckeNBdCDjiUrMH38WHz/8I8B+ACtEw9F88gQbfOex6AnhqNlWikDlpQ+kTVIll4DCHWaxZBW0puqUpIk3aDWZnfUurOPV5Kpt8TzHEjjG+GPHXRGK0YGDBcR+tK7fTcx3TJS+Gk3Gd6BGtq7SUMxp4qlRZUR6aIvx8xS0pq+EDTu4EwIqSnXTN5sHvHkcsycX4q0bTlmLL5/2KGYsaQ0SF81Ni5V9q5nLdTgZUXIjgQHZ0KIyjWTx5YH5uZsBldPPBTFTmD6UaVBuNhT4Zjjx6Jp/F7buaWEpEfbDfchm80g93dnb/Vbx4/vR6FYxLW5L9S0Df1jcPb6XUu8i/4tUkkSAwuLgYkWZbmt9Wl4JfEkUefafqentCmy0lu/9+/S8EqQkiQSZ7VVCE3RdcoMEVHemQJmbHZz6l2bev3S3yB3RjQHndl1SHk7GL1TdOxH9oy2hw71/R2Wtkti004yQtuw+kJ7nL0mRBLLe8fynvJOrXRGxh+mVSXev7H3WOW4mPGNnMrYc2O0LUxfwiGiX1ieVUt0ucRrciTMqbLFIvI/vh/o2YTcJaeU93f85CHkf/wA2r5xdtzsSRrqpET/GJwJIakzY+5ytD6+DK0nH46rjz4E1z21Am1PLkcwMIPpJ+tBPoQ0OrlLPwkAyM96ECgUkPvqaei45VHkb3oYbd84G7nLzqx5EFv/GJwt/+qSeAOwvP8C047VvmK19kg0daDSvxrlOb3rfi3rxNOyzrP8iz5J5hfvumvvmu0k9XutE71fV5Y+22uluWsUjJPZ/PXQftcCtD6+DG3TJqHlgmMQbuzGtR+bgszowcjfvRDByCFoueAYYJ/dy8eGu4yMtmM2neIryvvMWKxQ4wdXLpOWBaumomnPreV9kVYft7zLLPVofbDau0Suf5b3XyonGl4Fy1LGUr8g2GK/HKBn3PoYunsKaLvyU8hdftbmegxr9hNA+05CyFYUisXywCzJnTMBbdMmMeCL7BDkLv0kmpuy6O4poLkpGw3M24H+8eVMCEmV1guPAzZVHoC3HLAJ6a903PxweWDu7img48YHt9sA3biDc7W1vltuS7xZkizyeLUgLUAP0rBknPHI00nsBi2BJFqdGhZp0ivVavst8pwlgNCCpa8lkf01vIGOyrUtS497jIl+HzpElI1kO5l9KJSZnHaK1nrGpEzLunWJ5f5bpna058pikeq1sR0k5PpNSqa7JOvuk+CdevI8B16r2lr7B2h4gzdl/YMGomPWA8jPerAsZXfc+CDyP7ofyA5A7spz4mv2a0DjDs6EEEJIDeiY9QDyN9yHtm+eg9xlZwJA6Ys5OwD5f74bADD9e9Nq2gYOzoQQQoigUCiWBuYrzo59UeeuPKf0+3aIuQjCMGxIW9PC27+o/IM3y4i2Lda8BV1i/WAQySOhlO5kRKrEG9FZi6jlSudJYiXpjWq1kNa6Uu1Yr2Tp/bu8Ucje9aYaXpmw0nWQqwhMEdECTSJOsrY9rYj1tCKik5Ak0tty/b3n9UrSldpjea6SSNne++aNytcQZYKN0drsUP5dTWJKR+mn2V3Oq34uA4zWJoQQQuoMDs6EEEJIndG4c85JZFCD5BZIqU9kWJEEop5Qi9zzRgNbIsklsp2V5DFLhGtaxhASr3yWVkS3F6/cnZZhhFd+q4V023usdv+9EddJDD2SXHut/iSrIJJMlViMfJI8c5YySWxmJZWuVVrXT6JmFktgzey1EJYrGbwZp2hCQgghhPR/ODgTQgghdUbjytoamn91WhGLAxT52htZnVZEYqW/0RupmSQq1Cs7WSTrJJK7hlaPFmFaC2ohZXolcdmG3mdlW80oPqxdludQkkSGtUjKSSKJvQYmSaaAtDZbPLQr3dstsbwTNaq9J7zTFN4obm1VgXauJF7cWj0SbRohJfjlTAghhNQZHJwJIYSQOqNxZe0kEqe3zODKibRDaTxSi6jlNMwsLJJiEilTYon09ZqseCMuk3hcJzFL8EZ0eiU3b7+wTGf0bnuNMix/q0XW1MpbTIK06+TtI5Zr5o0kTxJB75VoJZq06r1u1d4TSQx9vD7oFvk6waqc1Hy/azAlxi9nQgghpM7g4EwIIYTUGY0ra1tkEIklOlmaikgPVbktPLfd0qRXcrVEoVaqPy3DilqYYxTktTd0P4uUZYlCTxKluq3mHttST5KoZa9c11vGsxLgw+qrVPeHtcUrBSfxTZYkkeW9z1CSlSEWaT0tz3hL+WqmNRJ1tUuCaTbv+9M7Lai1QcMb9e2EX86EEEJIncHBmRBCCKkzGlfWtkQsWownvFGwSeQ6SY9YUD9QRIN7ZaJK50oi7XrlQov8J9sQGK6fN3o8SbR5EpMIDU80/Ycda9lveQ5kmUpGDhZ5Lq1I+SRTJRKLnOuV0L3tsRitJDGVkWh/r7fve6cSKtWfZOVDkumoWqzc0FaYpNV3EsAvZ0IIIaTO4OBMCCGE1BmNK2tLvOYLFpMDryTuNQnIphQJW0nq8bZXw1veazCgmVwk8Sn2Sk1pybJpmZxoeI9NI5LU+/d560nLuMfSX7zTJpb93vSuSdqs3U9vSlWtvJZ6tlI9aa36SNLeJOfSyqeVRjcl+OVMCCGE1BkcnAkhhJA6o3Flba+8qEkcWpo1S8Sg1h7tvJby0qQjY/Azrib1WLysvX9Tkihrr5mCRdpLEuGexDzAW49X3tWOTTuC1SsFyjJdneXNYFOhQuEtPOi991bDUsaSQtF7HyTelKcSyzW3TAdJLDK+5dmt9j5IYo6TRBKXpJWqVusjFvm9s7NymZTglzMhhBBSZ3BwJoQQQuqMxpW1NelF876WaDKoJS2eN2rZIilJmgxt0KKce2UZ7ZwSbwSyRUpNK1I6iTlFksh9rR6v7KvVYymThgmNdX8v3ojYrq7yZrB+fbR//YZoe0A2KjNsWHk7HDw4KqOlFZVYIpMt91w7l1eOtJTX3iNpGVtYyiTxBt9WT3XN+MbyPpJYro03Ut5yjb3XzJsW1Qm/nAkhhJA6g4MzIYQQUmc0rqwt5QXpU53Nbl12y/Je2TRJNK1ASoDh0KHRD5pHr8QiNVU61rvIPomcm1YZDe990OR/r+SexMfZIvVZ+qM3hZ3EEjFcDdGWQP5N6zeg7eaHkc1k0HLhceKcpeew/d8fR6GpGfkrziodK6oMtb6WZDWARq1TK3rT1lqej7TMPiSWKbdK/uuyTu/f5zUD0fZrz6S3TkmSflSDCG0Jv5wJIYnIZjLI3/Qw2v/jidj+9n9/HPl/nY1slq8ZQrw07pczIaQuyH31NABA/qaHAQAtf3tSeWBu+8pU5L5+Rl82j5CGJAjDMOzrRmwLhffuif4niR+1VsZS3uu/Kkkr4rkatTC7SCIvSpJErEq8srzX/CJJlG0t9ieh0vW0nFPc/1iE9vtry5sdNz6I/K1z0NyURXdPAW1fnYqWL50CbIiiuxGK+kfsFJ12zO7Rfjk1ZYnolnhTpHrTBNbiXiXxdPbWn2SFQSVZ2zuVldY0Ra1X03gR7cnuev621yOg3kQISYWWi08qD8zNTdnSwEwI2SY4OBNCUqH99ifKA3N3TwHtt83p6yYR0rD07znnJJGPXs9i72J270J/T8SwNxLY8vdZ2muZFrDs90pcXrMZr1e6N9K/ltMUW5Lkb/dI3PI4uT14EACg4ycPIX/rHLRddgZyXzsdHT++D/lbZmPukj/ixL8ag5a/ORoAEPZEJkEdt89FoVhE6+emIBD+2+Fuu27732eJ3E2SMrIWkdteM4skz4dzCsPVf5NM7WnlkxiGaJiMdoRv9sBB1euvQeR2/x6cCSE1p+MnDyH/4wfKAzNQCgoDgPy/PY5fP7+qtG/zAA0AHfctRv7uhWj7/JTt32BCGgAOzoSQRBQKRbR942zkLpka2987QM995g/I//czAIDc2UfFBuaWiyZv9/YS0gg0brT2u7+s/ENaEcDS2KTJEDGaxOPWwrZGOXrla5myMpvAvKIWkcaWc1kkwiSR55pZQ1pRn0nSd2r7q01DWKZMFDOVoKcn2i+emeCVN8rb4Wur0XHvIuTvXojmARl0byqi7ZwJaPniSVGZfcdE22N2i+ocPKRye5JE8UvS8u6uZTT9lqT1/Hmj0Hv7RpJ3l3d1hIUkU0dJDJiU65fd/dO+NigwIIwQUnNy505E84AsujcV0Twgg9xZR/Z1kwipazg4E0JqTse9i9C9qVD+cu548Nm+bhIhdU3jzjlboua8C+41SVEi0uVBRJiqdVo8mpN4z1bDG4lt8eLW6t+eJhtJoniT9Au532uQYfl7vTJ7GhHglqkApV3SH1v6ZmNQdG06Hl1WmmP+3PFoueBYtN81H/n/egoYMRQtvQFh8lmS0ymaz7PlOiWJyq6FaY2GZSojSXu0tmnnqrbfKyN7yyeJ4k4iU3vfTd5r76RxB2dCSN3Tftsc5P/zydLAfOFkYFMBLdMmAQDyt88FgGiAJoSU4eBMCKkZhUIYDcyClmmTgOYBKNRi7Tch/YDGjdaW3toSS4o+70J8SRK5w2LG4TUkqHRei4mA1nYp2zc1VS6fxAvY4t3tjUCudRmNJLJ8kqmM7RVVnGDgDFavjrbXrot+ENHd4VARiT16F7FfpFO1tD3J85PEYMa7GsRyf5IY5CR57j3ye5Jn3otlitCSDjZJZLhlXBDXJLvLedXrNMCAMEIIIaTO4OBMCCGE1BmNO+dskSMscoeGRZaRhh1Bgqi/0FBGi1qtJLkkkdi0CHTLsVoZy7G19jvW6qlFhGsSvBHAFl/2au2sQcR9uHOUDjLWp0RfD6VnsWXlg4ZXyvbK4JYpHW+dlr7v/bu85/U+x5Xq96528aK1y5LqUyLbJt/bFt/sbTWASgi/nAkhhJA6g4MzIYQQUmc0rqztjR6WXtnZ6gYggYxalohzhVJayYoy3ohkzcM6rYjESr8nkXYtcpjmTb49/Yi9nsKWY71t1u6hpbxXdtxWidEbpWyJFhdyYUy+tpCW57J2bJKIbot5jDcq20JaJiRJzHsqlfEaFVnOmdZ1kiTxvk8r8twJv5wJIYSQOoODMyGEEFJnNK6s7Y3oldKajHxW5OJQGHDE0uJJ6VvUE2qSZRIDAK9JR++5vBG/XZ3RtiZBu81Xmivv18pva/o6a3lvGyzSbVrGKVp5y36JpT2SSv3F6//tPb8mgyaZcpEkmSpJyxveO1XiNSdKIvtbJGPPc+9dZeGV3r3X2It2jS2rYyQ1kLv55UwIIYTUGRycCSGEkDqjcWVtiVd20KQYr1Qek5qCyvu1dnolKI8Zg1fO1aRsi6xuiUb1SlMWU4ZaS5DaPewUUwCW6GtNKrNIikkk8W2dTrHIqpbzS7xe7BKtjDeqXe73Glho9SQxv0ky3WW5bhaDFK0/es7rjRb3+oVLLM+Pdq5mZZpNy8Wg9ZHtaEjCL2dCCCGkzuDgTAghhNQZjStreyU07ViD1BQq3sAoimybTYZobUvbLMYP1bDIfN60g1pbpPxjaaPXI9orTXvNFLxSpte/WGKR6y2yn/f6VLvX2nHePqqVSeL57DU/8ZoTeduTFkkigC3XRJOAk/xdvfVoUrD3nWxJyyvxTkdY/m6vuVNa5kQG+OVMCCGE1BkcnAkhhJA6o3Flba90qB1rkQillC1TQzY5pV7ZNs17WjMHkSYq1WQlj2HJlniiwj9sv0VOt0Q7SyxyniUSvxbXxFLe6yWcVmrDau2vdZTy9jyv1wjDIqdbpEzLdIS2P0nUuqW/eJ8VizGPp41aGe91TWLWkuQaa2UYrU0IIYTsWHBwJoQQQuqMIAzDsHoxQgghhGwv+OVMCCGE1BkcnAkhhJA6g4MzIYQQUmdwcCaEEELqDA7OhBBCSJ3BwZkQQgipMzg4E0IIIXUGB2dCCCGkzuDgTAghhNQZHJwJIYSQOoODMyGEEFJncHAmhBBC6gwOzoQQQkidwcGZEEIIqTM4OBNCCCF1BgdnQgghpM7g4EwIIYTUGRycCSGEkDqDgzMhhBBSZ3BwJoQQQuoMDs6EEEJIncHBmRBCCKkzODgTQgghdQYHZ0IIIaTO4OBMCCGE1BkcnAkhhJA6g4MzIYQQUmdwcCaEEELqDA7OhBBCSJ3BwZkQQgipMzg4E0IIIXUGB2dCCCGkzuDgTAghhNQZ/x9LgBM632CeSgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unique_peaks.plot_diffraction_vectors(\n",
+    "    method='DBSCAN',\n",
+    "    unique_vectors=unique_peaks,\n",
+    "    distance_threshold=distance_threshold,\n",
+    "    xlim=reciprocal_radius,\n",
+    "    ylim=reciprocal_radius,\n",
+    "    min_samples=min_samples,\n",
+    "    image_to_plot_on=s_rb.max(),\n",
+    "    image_cmap='magma_r',\n",
+    "    plot_label_colors=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualise both the clusters and the unique peaks obtained after DBSCAN clustering. \n",
+    "\n",
+    "*NB The cluster colors are randomly generated, so run it again if it is hard to discern two close clusters.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAecAAAHVCAYAAADLvzPyAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsnXdgXMW1xr+7K6265N6NsQ0EAoTEpABxEgihPkJCCCnwSKcYbGzcbaQVKrbcsQ2YmkJLMwkkIcCDhBQCJCR0QoBgYxvcu2S1lXbv+2O9V0dmj/eM5q5WK53fPxqtZufOrUf3mzPfOK7rulAURVEUpccQyHQHFEVRFEXpjAZnRVEURelhaHBWFEVRlB6GBmdFURRF6WFocFYURVGUHoYGZ0VRFEXpYWhwVhRFUZQehgZnRVEURelhaHBWFEVRlB6GBmdFURRF6WFocFYURVGUHoYGZ0VRFEXpYeRkugNdpbGxMWUduqYHLTuO40sfaDuSbUn6wK1DQutzbZr0KxBI/X9ZLBZLWp9+TrclqcNB69h8V9IO/TwYDHplm2vE9Nz6dQ1KrheuTuJ8+XVdcvUl+8rVb29v98ptbW1Jy7m5uUnLXDvV1dVYsWIFpk+fjimXn4KyPT9HMNaA8C9ysOruxwAAn5nyZQyYcxpO2TMKQ51S3Pnju/D3Fb/Bddddh2uvvRYAUFZW5rVZUFCQtA+S/eWwORfcvSs5L6naoW2Y3qsUri+Se1hyfUu2lY77trCwMGUdCVkbnBVFUbrC1KlTAQArVqxA2VYg/DWg5pfAqp8BTtXJcB0HT4cfBga/j9+UTwBqXgRW/Auo+jg2TR0HbM/wDih9Aidbl4xsbm5O+rnp27KkjuS/UNM3C+4/wlRvORJMt8nVj0ajXjknp+P/ONoO10duPyT/LXP1KZI+0/6YviVI/rtOx5sw1ze/+pDqTUiyfZs6HBK1h7790jI9z/Q65ZSchoYG5DS8hDWV56PyZ0AoB4i0HwzM4ZPjlWpeBML/AkIBIBIDqj8OVEwAXOAXG76BE1uGYdCgQV6bRUVFSbdLr0eK5Nrkzi3dF0kdbltdVTds2jB9u5e0k6yP0jo2MYJTIvPz87luG6Fjzoqi9DlCDc8j/LWOwJybi47ADMQDcSIwhwLx3wHAAV4s2JKZTit9Cg3OiqL0OSIln0T1L+OBOZQDtLUBTvULHRVqXuwIzJFY/HcAcIEJzSMy02mlT9Hrxpw5qVQiR1BoHZo0JJGGJbIy1yaHH7IpJ29x8pIkWYp+1/TYmA4LSL5L+2wqoXEyqGRIIR2JfxSuD5yML9nHrm7fVOKWSN+S4RwqWYdCIaNt0e+WlJRg0a3PovZnQNU3O8acw5UvwAHgOk5c0q7+OJAYcw7/C3CBr8/+Hs4oPgEo5qVsU0nZdKhHUkdyH3RVnjZNxqJw9TmpXvLMMu2P6fNW0r6kTVN6XXBWFEU5HIsWLUJtbS3Ky8tx3fc/i+at92L2pP1oHBDE4sqHAQBnzfoGhkz5LD67ZSyGXfEdrGhZib9U/hJHNp0JzMjwDih9Ag3OiqL0KaLRKMrLyzF37ly0traiuTQ+1nztnEb89cV4KvaaK2uAXfH6ubm5uOeqJVjdOopN8FIUv+nV2doSOAnFVJbj2pTImqaSTqo2JfONbbIU/ZpLTLGZC8tB58LS+lTilLRvkylNP6cPdskwi+T420joya4XibxsM/dUMlzA3RuSDGcJEmmdnitOIvZrLrekjs1j2mZ+cDK5VjJkYir/ct9Nx/nnMJ3pQaF99muesyaEKYqiKEoPQ4OzoiiKovQwet2Ys8QkxDQj0lRqkkjAFE4aksh+yfovkc/8Ok5cH01lKoqN/BeJRJLW52R2m+NgY3JAy6YGDKYZz6YzFZLVNTXrMb3uJMfG5jiZDh1ITHdMZyRIkLTp1+wO0/OVQPI8lNxvkuPKwRkkmRqY2AzRpENap+ibs6IoiqL0MDQ4K4qiKEoPo1fI2n5lQZpmHtrIiFROobKM3/64pvtkKqWZtkklLorpKjpcf+iKQFx2tF9ylI3fNJcZymGaMSoxxUjUNx3K8AtTL2aJzM4db4mREIVrXyLLSjKVTSVxG198yawP0+OcClPpmCIZeuHOp2SWiGRGguT4cefHL/TNWVEURVF6GBqcFUVRFKWHkbUmJC0tLV6ZMwwwlUQpfnlAm2Z6+mE24Jf3sc0xoJj6VHOYZBrbYmowIpE46XUqkeX9krtTIRm2Mc3+tTFxoPg1a8L0mpU8O2z6YDP8xknrkvvDD+MU02eHqURsaqaTjvPM1ZEMa6gJiaIoiqL0UjQ4K4qiKEoPo1dka5tmVttIgaYZjhIkfTbx/ZbIWxIpSJLVKKkvGWqw2S73Xb8y1SXbkkj61CCl/f0NyHnvXbSPHgtn+Oik7VCJ22YYxGQ4wFRGtjGVsZGOTe9hvyRxyRCHZF84JM8Um+xn7nOTPpueK04K5jzLJX3nkMz6oNgML6SbXhGcFSUbWLJkCYLBIOaPH4qBtTPgxGJwAwHUz1+Gheu2IRqNoqKiItPdVBSlB6DBWVG6iWAwiEWLFqGgzEG4NP4fuBOLYdWs6VhSD8y5ZlKGe6goSk8ha4Ozje+vqTxqmulN8UtC76pcb+o1ayPnmO6rRPKzkTslbUro6vDCoeVp06bBee9dVD7wCzguUFEG1OwHKuuB6lKg/Pd3oPnk4xD5yuWH7XM6vX5tzHokfeSyi/06bzZytOmMhHQMoWVqH7s6o8K0v+nIxJZcjxx0WVk6jMS1n25jHoomhClKNzJnwnGoKgXC9UDee/Gf1aXxQO3EYiiovh7Ots2Z7qaiKBlGg7OidCOhF55FuAwIAYgg/rOirOPvTiyK4HvvZqh3iqL0FHqFrC3BJstaIr+ZLj3m1wT8rmKTrU3xa8k1U3mMIskS9sN8AeDlP+440IzUvLw8RL9wIaofecILzBHEpe1EgHYDQQTGHYPc3Ny0ZBWngpM6bWYA0HY4IxYuSz0dZjM22dQSud60z6bXqU32MNe+iRe7X883m2eHX6Yl9FpLhwGTDfrmrCjdSN07W1BZD1SVAq2j45J2uD4eoN1AEJGq1XCHjcx0NxVFyTBZ++asKNnG0qVLsXDhQsyfPx9Txw9F6+MP4foPnYCWrQ0I//AetHz7asz/6rcz3U1FUXoAWRucJf6yEvySi23kaBsTkmT1/coWtZHbTI0SbMwDJMMONhK3pM8ch0qcFRUVmDdvXvz737wCQQDlAIIjjkA0GjX20zaV/ZIdB/r39vb2pGXu/NByKBRKuh3aDs2OlZwHTuL2K1Par4x+Gyk73YYqFEn9VMfZL4MOyTPTRkb2S5ruTim7U/tud1qe+Ahd+MJ0epPEvFyCXxemqctOqm3ZjFuZTp8xHYPtzuBMsbkhuf6YjqWn4x9BmwdysuBMg2d7ezsWL16MYDCI6dOne58njseyZcsQi8Uwd+5cAHxwpm1KgjMNyDbjzzZjyDYB07S+TQ5EOvpgcn3ZjN9LSEdwltSnmC5eVFBQkHJbErL2zVlRlPQTDAZRV1cH13Vx4oVz8OT6PEwY0Ybn1i7Bz26rw/z58zPdRUXplWRtcOaWIePqcP7O9Lu0vunEedPsRIrkbZlKg6m8qiX/VXLHz6+sU9O3TdO3bu4YS64LU0mcw69sWtMZAJJ2JDJ+on3ue21tbZg6dSqi0SgWLVoEPF0AnBrGT25bCjyzAM6nqzDsrJlwnI634QT0PFBP8ebm5qR1JD7i9LrPyel4dNnMNuCOt+mbqomydbg2JfUlzx2/PPWT1bGZISB5HlL8Gsrg+szFCO67pv23IWuDs6Io3cMJX5oLPFMEPFMJ/H0BEI0An66Ge2oFrn/UxZnj2zGyNCtHxxSlx6JTqRRFOSw/eSkfODUMBEPxwBwMAafGF+iIug7W75E/Rm666SasXr0aABBs3orSd27FoFdmIG/bH7Bq1SqsWLEiLfugKNlG1r45UwmCk2I56cs0c9cmKYH7Liehc3Uk+5vsM06qkyzjmI4MR8l3bYwnOBlMIvNxn5tm3Ntkkkv64JfEnUzGo58lpGYnEACeq+kIzNFI/PdTKxB0XBw92EEwGGSzuA/NAF+1ahUCu17Ckk/+CYlervzhw1j+e+C6667rdN3n5eUlbVOSiMjh1xCK5P7gkCQfSa5fm5keXZV005H8KjmuJkM1h8IdP8nzwmamhw1ZG5wVReke+r9cDTyzEPh0dfyN+bka4JkwHLhYtXC2kaR99dVXIxA9gGW334PS3UDFeUDNY0Dl74Gq/wG+e8lxadwTRckeNDgrisKybNkyPHhnHUacG8aWE8rjH55ajoEFMez+QyW2PdkGTJhj1OacL4/C4PeA8O+B2v8DIu1A9f/EA/X+zQ+j5eiL0rAnipJdZG1w5uQR02xjG+lQIu9QSY/LKuba5JY/SyUl++V3bSOrcZjOc5a0w33XZv6oJFM6HWYMphnAfveNypv5+flwHAcVFRWYPXsWHnu7BU++E8Q5x8TwPzVzUFcXQzQa7TR8lGybNBM7FAohL7oXFed1BOZQTjwwA0AsVMrK41z7nF+36TAOxXQ5Uxu6agZyuPq0/xKpl7ZP63PHzaSuxMeBg6tjej4lbdoMF6VD4s7a4KwoSvq54YYbAMQfsOcdE8V5x3QE44TTmSmNg8/AmjVrvMAcaY9L2+XnAW3FRyG9I3mKkh1ocFYUpVtZcf/TWP37Dim75rG4xA0AU0ZvwgdnTStK3yNrg7Nf8oWpfGljM8nJbxIPY9o+lQm5baXql19GKTZSuQS/LC9Ns6ZtrDklQwBcO/QakQxx2AwHHO6zw/VRIudR2ZHaGS5fvhyrV6/G/EkXo/z4XwHokLTDvwdajmjBvM931JcMU9A61B5UcmzSPYzDIbnWuDqSvkky0iXfTXaubeTcdMw6MMWvPts81yRkbXBWFCX7iEajmDNnDqbNmIHIHzYitOdfcBCXtKMFI9FYNDbTXVSUHkHWLnxBbQAppv+ZmSZPmb45Sxaal7w500UFOKtDE0zfflP9N32475paBpomwti8tXJ1TG09TedIcm+EXAKh6ZuzyW1ten6473LQfaL3bVtbG0Jbn0T+tj+hfeRZaBt5NoDOb9r0DVxy7FtbW70yPTb0/uHatPE8sCHd17hNciMl2Zuz6XWfrD0p3TnH2FSdon0rLCz0pw+9LThTbB74XDuSi54L5jQ4U/mt077882UUvPAKmk8+CdEJJ3ofFxcXe2Xu5KeSLP3KIrYxa5H8o2PaN4rknKTKQO0KfhnYmK7mxW1L4gecOOamwUEig0vOg83DlqtP/xGg9xsNzlw7mTKboJjeZ37NNjF5VtpIzTYe5Oke4jLtA3fMdFWqXsRNN92EQCCAqo17UPSr38EB4AI48JX/QeWYgYhGoygvL890NxVFUZRuQoNzDyAQCGDFihUoQwHCiL8VOwBu+vVa3IRmTP/BFZntoKIoitKtZG1wNs1k5Cblc+N6Nss7crIJV+fqq69G7j9fQuXTca/hChSiBk2oRDOqUYDyHz2M+uNOQvOlF3+gb8kk2nSMA1NMjw1Xh/PzlWBqPGIjX9qMP5oeE5sxc1M/4GRLRvolk0r6yN2TnEEPzbWQ3GOSZSU5JEMKpkt6cpj2zSYnw/T+SNUe14YN6c6CNs3El8SLtPTT9xaVLjFr3LGoQgHCaEYediN8MDBXoBBOLIbS2VUIbNmW6W4qiqIo3YAG5x5C4atvIIxChABEAIQQf4NO4ERjyNmwKVPdUxRFUbqRrJW1bbLsTDODTZcbMzWwCIVCaDr/LCx96XkvMEcA1KDJC9BuMADn6KMQCoVSSoY2sjNFItv75V8uye6VeC5T/MoGtpGsTKdhcEiGTbq6xKhpX2wygblpY3QKFJ3JQKEZ19xSkqZmI5R0TAWyGTbh6qRjuMG0P8nattmmTTumJiGmsxo4JEtu2qBvzj2Euh2bvDHmVgxE9UGJuwZNcAMBNK6ogTtyWKa7qSiKonQDWfvm3JtYvXo1Vtx1pzfGDHRI2mE0Y9/3/hc3/O8lmeyioiiK0o30iuAskawkTko2koipVEZluZycHMy/djLKb/sFQPpZ7hSh5dofIFpU2EnSSyXFSCQwU6ku3UYVHKYZyKbet6ZSGZWyOMc3KnGZyl02mfZ0W7RvqaTedDg4UbgMbSplNzQ0eOWWlhavTPepqKjIK9NMbBv3OpshC5v7n8Om/6azREyHlZJ9xl33ps8R03MomaEh2VeK5JhxfZA8y0zpFcE525k7dy4AoOmYE1E4vRxONAY3GEDzTbWYdfnXMtw7RVEUpbvR4NyDiFx+CSJnfBqB9RsRGzcGzuiRme6SonQbK1euRDAYxBVXXIGcPdsQ2rYR0RHj0D5wGG699VYEg0HMmDEj091UlG4ha4OzqTE5912KX56rks+pLNfJSGTsGGDsGBwqhpoYRZhKuxx+ZbtL5DZTuVtiEiGRvrn6FC6rmFtkgZ5POhyRn5/vlTmDDFPZUSJxU0yucUnGMncOOemTfk6P6/79+9HW1obVq1cj+vo/sXLvM3BcF67jYPqgz2D143/FtGnTPMmb+hebLgTjV4azjcEP145fGeOmxkxcm6mGzWyylE2HC9OxPgJ3/OiwkN8Z7lKyNjgritK7uPLKKxFsPoDVP7kPg0YAFcOB2i0uVv7rr5h0+aWYPHlypruoKN2GBmdFUXoM0089AUOeAMJbgNqtQMQFqkcA3zjl+Ex3TVG6lawNzqY+qBxcHSq5UQmS25apwYREJjSVVhL1OcnUNDvTRv7jJCtOepVIbNx2JZKf5LqQXAs0k7i+vt4rRyIRr0xlVpphTM8tJwdKzF4kx9xk6UnJ+bcxkqB9p8cymXmIEzj4xnwwMIec+O9vw/VtOEWCzXCQqdxtk6HPbVciAXd1ZobNTBbTe890v02361f2eDpkbTUhURSlx9A2aBSqSWCOuIj/PnBEprumKN2KBmdF6SK33HILbrvtNgDA6/sLsGb9EPzy/QH4844iXFn3E4SX35HhHmYfa376S1RuiUvZrRPiPyu3AHf88teZ7pqidCtZK2v75VnM1eekbAonQUsm40ukIU765OTaRH2JvCk5ZqZScKqlLA+3LW5Cv0S+5uCySk2HPjjjjLa2NqxZswaPbynEfyfWATjY1hPVwGNLgfOq0Pb3Uiw4fjOAzhK3zbCMqQzNLc2YKHPe1H6ZvnDnk8r/ZWVlWL16NVau/Q2qRjioGB6vVzEccB0Hlb9+BMXHnICZM2cCAGvKQzGV4iVSJvddbrumWfY2/ZRc4zbSeuJzyewLru+Sc8UN50m+azOUZXrO0yFlU7I2OCtKpvnud7+LHa25+M29i4GmIuDsCuCJGuCxSuC8auDsCvx2q4tvjNqNE8taUjfYx4lGo5g+fTquOLo/3B9VwonF4AYCuCpciz1vbGfXeVaU3ogGZ0Wx4IgLZwI7hwGPhYEnaoFoxAvMcRy8vK9Ig7OA66+/HgCwv7kZjSdORGj7JkRHjkV04HBM/jzQv3//DPdQUbqPrA3OEvMDm0w/k2xXgJdxaX26FB6tL/GJNclmNvWINcXUNIMika8lBjN+LYsp+S4d4jhUfjuxaB9wdnlHYA6GSGAGABefGBRBKBRizTJMjSS4fefOS3Nzs1em2eaJduj+UXMP6v9u4+1M33jpPUD7Quvk5uYCw0ajbdho5OXloeOodcDdn5L7kJKO60ViAOLX/UeRmPfYyLKJfZGcc4rNrA+bWTA2meEcNt81RRPCFMWCd5sL4lJ2IjBHI/ExZwCAiy+PrMdH+rcetg1FUZRDydo3Z0XpCTxw7z3AY4s6pOwnaoDHwugXbMPia7+C08cVpW5EURTlEHpFcDZZ7uzQz03rc0gkLkkGuKlhgAnpyMSV+PaaeuX65afLYWrQQM9baWmpV161ahU2PbwKOK+qQ8o+uwKAi32PVOI/Rx3A1yorvfpUJjbNBjU9blTK3rdvn1emxikJiZlK2WVlZV6ZZpdzfZd4E1Mp+8CBA1559+7dSftI96OkpMQrDxgwIOnn1LPc9PqlmM4AkZwfyfCOZLjJxrSEa6erJjemsr2paYlNdrzps8PmmaLZ2orSQ4lGo5g6dSoeOm4ONjW7iE+lcnHEl+fhKx/am5Y1XhVF6Rs4rl+vI90MfTPgsLHCs7Gf494abeYNm7wF2Px3b5oU4dc8Tsl3TRNRKKZzWCXQt8P73gzgkY05uGBMOy4/tuOYSNQSSRKg5HjS/uzfv98rb9u2zStv3rzZKyfuIfq2PGTIEK88bNgwr0zfVCVvNrTvTU1NXnnnzp1e+d133/XK27dvT9r+0KFDvfLo0aO98uDBg71ycXGxVzZNuks3ptc+VRk4uGtKkkhpk/SWuL7SkeTGbVOyHxJ/BZvnkelzmypRNuibs6L4wGXHtOOyYxK+0ZpnqSiKHRqcFaUPcMcddyAQCOD888//wN8eeOABxGIxXH755RnomaIoycja4OxX4gwn73Kr59j0x3SOnGniUqKOXxKuRFKSJIek6u+hmCa5SI63ZF9Mk7SohObXovOmc9QlfW5paUEsFsOdd96J9n3/RMV3Yniv8WS42IPfPvIU7rtvH75xyfkIHvgr2opORgRxaVviyCW57um91NDQ4JXXr1/vld966y1sGHM8Nh15AvKbD6C1qBRjNryOC9re9+pQExJalsyXN71OKTZJWqb3HJXl6XGTtGM6DEIxOW42w2CmfeHuW7/mttusVpfuYZOsDc6Kosj57ne/i+H4BWrufgFHFAPl334JNT8Blt4HVH0fqPjOo3CcR+G6AbyDWdiOC7qlX48//jgCgQBenHEztg8fBzgO4LqA4+DfT/8Zzzbtx8KPH9UtfVGUnoQOjilKH2CQ+wiqvtOA6h8A4buB/M8DlT9E/PfvxmMiADhODEdhKULY0S39CgQCeOyxx7D94QdoJ4DbaoBbKrGvsAyvDTiiW/qiKD2JrH1z9suOj0p3nBRH26Sr4dDvSuxETWVKyXzMVHKKqTWk6ec2cq5phrZkDivFL8ldIoPZrMJF8Sujn879LS0txdADz8GJAhXfAWrvASJtQCg3/vsH249hcNF+47nNXB+5oaOmpiZMnDgRrw4Yg823VMaD8qSKeGC+OQxMqQYmVeDVjS/jmK3/TblNQDYkYjqf2XQ+rg20b1xWto1sLrnGU+27qfxrIx3TY2B6X0m2y32Xe7Zz303HpCd9c1aUPsD+3M/DBVDzk47AHGmL/34oLgJoDYz+4B/SxOfP+BwwuSoekE/K6xSY4bo4bte7qRtRlF6GBmdF6QPU512EG39SivDdcSm75an4WHP4bqD6x/FhXiAemLcUVKI9MOzwDfrNpAogNwS0ReI/J1Wk/o6i9GKyVtbmsJFWqJTBLfhN5W6aWWnaH4kcxUkuqSQ6UwMCmwxXG7MD0yEIDr8kJdNMb9P+S6R1yXGWnEcqaw8bNgzLly/HorvrMXfyOZjxHRe7C87GtVP3oj34Y1TeuQUHSq/CrGvORG7pcSjMHYlCdB7C4bbDXcdU5qfyOLXgPPLIIwEAT436GHB7bUdgbovEpe1JFYDjYOMRx+PMnNZORii0b9wxMx0GoZhaW3LfNcVUpjbdFpcJ3dUZI35ZiZrWsRmWk/RNMkwlGR6xodcFZ0VRPkg0GsXcuXNxzTXXIOFoHYvF8P35V6Cp5Ga0x2JozT8VObndv1BH8x2LgZ/+uEPKTow5A8DV5TipYUu390lRMo0GZ0XpA8yePRtActvbadOmdXd3PB566CE8++CDKPnedDRcXR7/MPHz5jAGRBpx8ukfzVj/FCVT9ApvbRt5lNanvrac5EPlNBtZhmI6Kd4EG9nJZpUeU7i++eULLNkuJ32aylc21yP3XW6YRZIx2tXryzRLWTLE0djY6JV37dqFW2+9FYFAAF/96lfxbG5/PJ83ECXtETTkhHDg9oU4KieGa665BgAwcOBA77t0xSya0Uu3K5G7TYd6KKamH6aZ0tx3uX6afteURPuS9jgDG5v7x69nhOnxNl0/oLCwMGUfJGhw1uCswTlJfQ3O3ROcE9AFMSh0jFqD8+H7qcG5dwVnzdZWFEVRlB5G1r4502XoKKZvsH4tecjRnW/Oyf6zlbRBM9A5UxHTjGWTxdsPRXI8bIwh/HrDMH0TslEBuCxbG1L1gXtbl5x/yX1I249EIknr0+uRviHTz7n+2LzN2mRlc21KrmVaNjW24fpgSlfVMMm+ml4vfh17CrfEJPcclKho+uasKIqiKH0ADc6KoiiK0sPI2qlUNskVEombyhoSSZdKIpwnrqnkTssSr9dEfUkCE21b4o9ts8yejfmJqZRtei1wmCbgmCYfmV6nkn5KZNlUbdK/U6mZ7h8nL0skUFqHmvjQskSylJQ5OP9lDr+MRyT9tDENktRJh5ScDIkkL8FUYpfU5+5Vel1z14XkPvcLfXNWFEVRlB6GBmdFURRF6WFkrawtkXxMpR1OspD4WnMyuCkS2TSVTMnN9eT6ZTOnl+sjl61p40drs+SmXxKezTxNiSQm8dA2lY9T9Y3bDucdzw2DSPbVr6xjv4Y+uG2ZDhekW172y8PehmTtcNvnMv0lZcmQmOlyvX6dB274Mh2TnvTNWVEURVF6GBqcFUVRFKWHkbWyNsUm89XGeEAig6RDHuNIJTuZSvumUo1EzpfInabLJtpkSre2tnplzgiDyyqWZLlTJMMK3OecwYPp0IOJxGm6PKapmY6NPazpMTO9rm2ufRsjJMnQmqkxj6kRislwAPd3Sba26fOT9t0vSdn0+KVbyqbom7OiKIqi9DA0OCuKoihKDyNrZW3TDEe/JF3TrEIuo5tik9FrImXbYCprmrZJkfjy2si5VMqur6/3yvv370/aB7oCUmlpqVcuLi72yjYyHtdnDtMs966akEiGYSQe6lxfuO2aytc2hh6mRjWmmb7p6A/XDnddcJnNXR1ak0jmpkM+FNMhEZthBM5Eh36XHj9O1ja9JyXom7OiKIqi9DA0OCuKoihKDyNrZW0OU6mGTiqndTifVVMpwybr2w9Mt2Nax9T/10b+4yQ0iVkLlaZaWlq88r59+7xBwPl+AAAgAElEQVTy+++/75XpkqRlZWVeedSoUV45FAp55fz8/KTb5coSkwabYyuRaJNlj5saN5hmoEuGLGxmX5j2gTPs4c6PBBuDFD+WjD207JfkmqodbmjHZuggHcfJ1MxIMhyZDvTNWVEURVF6GBqcFeUg999/P37605+yf7v33nu7uUeKovRVep2sTZHIKZx/sGk2oOl2JZ7XXfUbNpW0JNsx9cqVbEviF8zVp8MR1DyE9oFKzVSaovtC5evm5mY89NBDaGxsxAl5V2DPXz4K13HwVlkN/vife3Dhmd/qJIlzQyIS8wvJsZJcg3RfKDZmMgna2tq8Mj3GtL2CggKvTGV+io1vNve5qSQuMTmReOXbDPv45R8uwbRNEzMmzmvaxiTG9J6x2T/Ta4TDj3vscPTq4KwoJlx44YUAgIceegib8FFMwHl4ETV4YcsanIxqDP1jOf4Y3oMzq9/LcE8VRentaHBWspZFixYhGAxi6tSpH/jb8uXL4TgO5s+fb9Tmp/pPwyZ8FC+gEi9hAWKI4GRUYwIqAABv/W4ATvjaLgw9odmXfVAURUlG1gZnU8MDUz9dLnPT1CSEy2C0MWzg6qQyCZC0QTGVfCSZuKZtcuehtbUVruti4cKF2N+6E0fd+Bp2F7yOYU2fwiu1A3DXkrWYO3euJ8dSiZsOZVAptqCgAPteGYcJ+KwXmAMIeYH54N5g738G4KhT65GXl5e0z9y1wNWhcMeHSsyNjY1emcrstH5hYWGn/TpcH2gfm5s7/unYsWOHV969e7dXptf0oEGDvPLAgQOTbt/GN9tUmjbNjqdIhpq47VJMh3o4bKRbSX8ksnKyZ5lkdoQESb/8Mu4xHYK0MTbxi6wNzooyffp07Mh5FbcuvAsTy4BPVwA/v+mP+NsS4DNVDs6ePgxoTd0OZfAn3sOTL/zIC8wxRPAiakiAdjHy5JbDtqEoimKLBmcla2kIbMHQ2scxMR/4Wxh4rhaIRoCJ1cBpFS6ecGdgbNvnURIbIW7z77tvwgtYi5NRhQkIx8ecEQYATEA5TvhKA0aclHz1KkVRFL/odcHZZqI6J4Nx0o2pjCvxa6V0VYqxyfK0kcYkbUqyjiVmBo7jYF/Ou4ATf2NOBOZgKP47ALhOFPtzN6Jf++hO36Ve2UOHDvXKd911F9auXYtJkybhtEGX4bWf1+MLzvUY3a8RDz8fxke/vg/fur0CQFy+5bKTTWVNThKjx4T6fm/ZssUrU7mZXkfDhw/3ynQfqdyc6BvtI93Of/7zH6/89ttve2U6LHDccccl3T6V/E2lTxuPaw7umuKGTSSYZpub1uGeNaYe3RJMll01lX85TLOp/TJrMh0KkMweSIe3dq8LzkrfoX90HOACz5DAHI0Az9QcDNAukBtLPt6ajFgshkmTJuHKK69EW9sefOiLe+Lb6f8DjLmlBbFYW4oWFEVR/EGDs5K1lMRG4KWqwfhb1U5MrI4H5Gdq4hI3EP+9LdAMCHM1rr76avZvkydP9qHH2cnatWuxZ88enHHGGR/42y9+8QvEYjF885vfzEDPFKX30uuCs+kk+1SZiYfWp0gmy3PSN7f0mGnmeSqTABsJynSSvY0/MudfS9uh/cnPz8eSJUvwxIKdmFjVIWUnfv4tDDiug6kzj0Fubi7bH+qbTSVfCpVx6XmTGGFQkwaJdEjLNEObeoCvW7fOK7/42g7sPjAAA4v3ID8/H7vq+2NQ6V58akJHJhzN1k4ma1M598CBA155w4YNAOJS91NPPYW33wFyimegf+k7KMrfhW2bH8U7/30B5557Lt55551OvuMDBgzwylT+T4f/s83yoZxcLBkSM5XobcxGJEMDEsMTU7MPP2RlUxmZYur1LjmHpm1K+mk6JCKh1wVnpe8QjUZxww03oGj+A9jvbgAcAG48QDuug6Mi56HUHZnpbvrOgw8+iEAggP7jZ+LuR78OFwHE5QEH2F4LoB1TJp2Csz/uj1nKF77wBTz9/Ifw/qZbgILTsaGgHGiuBZpfwPEnfQtnnXWSL9tRFKUDDc5K1jJv3jwAQHv9dLya8wD+m/cYRrefhuHuR3HN1LEYmHNkZjuYJgKBAB588EFg6InAkE8lPgW21wA7wsCQatz60ImYcPRODCqzn/b1xn/HoiU4CygYAjSH44EZEaCgGm+8fwP21d+NfqUHUrajKIqcrA3OpkYCEoMBUx9kU8nHL3/cVO3Y9IvzGpZIXTbGDRTaDncOqbwcCoVwCq7AKe4VQEIdzzGXHTnJmpPBuDKV6KkkzklfkmEQ+t2zzjoLW3aG8OxfKgHXAYZWdArMGFqBmAus3xxAQU5jJ2k92fGkx5VK0ImM6/9uPAaAAxRUdARmhICCCrgusK9+EAYPbO10/LgZCBLPalP50lQSpX3wS7KWbJdr32b2A9cmh+m2Ug1t2XhKm+6HZBjJ1Iub64/p9cgNy9mgq1IpShZy9Ed/AAypigfk1/M6BeY4Lnbuk2eqH47iwkYALtBcAy8wI3Lwdxe5uTrvW1H8RoOzomQhb74/HBgaBpwQ4EbiP4d2thldt2Ug+30TDjQVHRxjDgMF1cCA1vjPgxJ3W1vy+d6KonSdrJW1OThpVSK5cjIb/dzU65eThWyk9VQynmmWul8+5abZn8n6DvBStqmUJZHNJOeH1rHZR9OhFSox9+vXzyuPHj0axx7p4B9P13QEZjcSl7bJm/NZp0ZxxBFHdMpITzZLgG6TZlmfdFI80euRR+8EmtfEA3LBwfYTP5vD2L7lCnzlwks7eWtLhghMs4Il14Iky5obNpH44NssK0jxy7zHtL6pB3SyfTf1i+fqmMrRpjNxTK8Lm+V1beR9jl4XnBWlL9CwcTGw48cdUnZizBkAhpbjxHENmPiRfYdvRMjI4Y3oP2wW9kbKD37iAnAQKLwBp35iJwry633ZjqIoHWhwVpQs46c//Sl+/eD9OOWMa/GPXeVwAWBoOcYM2Y2Nr4dx2offxbI5V/i2ve985zs45ZQ38eqbj+Hfb4/GkSN3YeCABgwZWI9TPvkV37ajKEoHjpuO9/FugC5tR/HL05XLcOWyUE0zA02lXlMZp6t9MfXwlfTXVGaXtGkqNXZ1iOBwdSTt0OuFXlNUQuWMSui5oEtDhsNhbx3r9e9FsHFbLsYMa8PoYQ5uvvlmxGIxlJeXe/Wpl3gqaFZ4fX190jLdVyqZl5SUJN0/01kK3LGXtMnJ1Nzn3LGXzFrg+mxqeMIhyfqWfNevazxZH7gZBdwsCJsMfQ7T68vmPEj6zC3Raoq+OStKljF9+nSvPGxgO4YNTASYXEyZMiUznVIUxVc0W1tRFEVRehi9Ttam2Ei0nGGEX5PNTX2uJd9N9FniC25jmtKTl1kzzQC28TLnpFKuHU5OlWyXbot6btPrlBqecHIjJdXxp9un26Tfo/vEZVPT7dMyd2y4fkmWfZRk6HLHlTOVMPVo5pY/5bDJMPYLkzBgY9ZB8SuL32ZmiOnym5JtcR79puibs6IoiqL0MDQ4K4qiKEoPI2sTwkxlEE6+4jJuJYYEFBvZya8M80SfTeUZmyxVSX8ln0vgsuZNTRHSkaHNSaJ+eSvTOtwSjJy5ho2PcwJOMufgMndN4SRuyTVL+yzxa+cwPT+clN2d8q4NfswA4dqzMfrgnuccpkMcXZ0Rc7g+26BvzoqiKIrSw9DgrCiKoig9jKyVtSWYetNy0jeFy1rlpEZTSYfKgcl8kIHUBgwS44N0yDM2WdySPnMGHTZevKYZ49x2JSYqEjnVVK6jdLVNm3Nuem45z22JFCzxJueyrDmzEYpE+qRIMsC5bZl6ZZua9EjaNO1Poo7pvWc6U8Y0s97Uo7urQzuHq5+OmSf65qwoiqIoPQwNzoqiKIrSw8haWZvKCFQKlsgLnG821z41PIlEOhaW57Jy8/LykrYjkVBMl3JMJjH5lTnKYSpZmUpvkmxnrn3Jdm1kLdMlALmhBNPtmmbu0uuU1k+WwUzvH4lcLPG7lgyhSM4JlcE58xPT+1nyueSaklxfEq9vifmJ6XCQRGKWzHLo6owNU3MPU2yG5STnVrKtdJO1wbm7WbZsGQKBACZPnvyBv61cuRKBQABz587NQM8URVGU3obK2kICgQCWLl2KVatWIfeVt1B816+R89KbWLlyJZYtW+abraeiKIqiZO2bM+fRy0kTVPqikl9ra2vSOvn5+V45Foth2rRpcF0Xy5YtQ9mKexHGYFRjJ5ZhF6ZPn46ZM2cm3bbNBHaJzJJMPjKVZzgfZNNMU78ywLlsV0mmtMRPXSKncn02XT7QL39yrs/cd7lzl8znmrs36PbpbATOkISTuCVlDklmsMScgpOLJc8R0/uJboszY5H0XzJ8ZDqk44dXtc39I9mmaeazjcmJX5nbklkWpuibswGzTj8PVRiESuxCHt5EJXahCoMw83PnZLpriqIoSi+izwfnFStWYGntamx9Ng+NW4Mf+NuyZcu83/P/8HeEMRghOIjARQgOwhiM/Kee7+5uK4qiKL2YrJW1JbIQJ1lQGW/nK0Hc/9RSvHZHCU5HOUIDIiga1YaXx1bjR79Ziuuvv77Ds3rYINRgpxeYI3BRg524bsRQuAIJmJNTbPxmuW2lakNi+uHXcm2mpgzp8MTm6ptKh6ZZsH6ZRFAk1z6Voam0Sk10EhL2vn37vM8OHDiQtO3i4mKvXFJS4pULCgq8suTcSrKjJZK8JBucW4aSW9LRxkve1JzCLz990+tLQqr7TPIc8WsoQ3J/2pgcmT6HuTbTQdYGZz84sCWAo59agjNQij8hDAA4fU8FntizBH96dSkuGB7GlCnf8erXbXwVi7EL1RiECgxGDXYijF1o3PAK5uKSDO2FoiiK0tvo08H53z8qAODgdFQAAP6EMP6KWkQRwRmoxie2luO9P27Dh74Yl7iX3HYr5p/zJZQ/+Q4Qi6E8MBQtZ0/EwttuRbB/GWbNmpXZHVIURVF6BVkbnCXSZyrJZ9drHVmnp6PCC8xBhLyAvfWvRTjx4rgMNm/ePMyZOxcHNu9AYP17cI4eg/kjhyKwaBGi0WinLNZkfZB8nk5J12apNImpgMTUwLRNU7mbtkMzjzkpk/NEN5UOTbO4JZmenOTGlSV9o0M6DQ0NAIB33nnH+2z9+vVemZrpjB07NmmZXvP0uHJTC03lTnreKJJhB0kGranRh40JCdem6X1jKitTJPe3ibzPGahIMrclbZoOs3FwZjBcHdPtpmMqbdYGZz/o96E2bHk6H4CDP6PGC8xRRPBn1OB0lGPE6c0AQp0MRtyRQxAdOcQ7IWo+oiiKovhJn87WjkUCSATmPyGMM1CNMFpxBqrxJ4TxbGkVjjizJdPdVBRFUfoYveLN2dRgIiHXjT8nitvvrcafUIkzUO1J2fGfLv6vvhJ33BHB/Pnzve/aLLtokwEqyQZNZhJgun0bIxHJUnw2mekS2YmTi037QLHxCeYML7gyJ+lRj2nOBERyfmm29tatWwEATz75pPfZY4895pUHt/bHkW3DsSF3Kz75ldO8z7/0pS955aKiIq9MZXCb7HuKRC6kUj1FIuFSJOY3Em9qDr/MaSg2pjimQzeJz00Nekyfe6bDYJLrS3KNSNoxHUawoVcE564y9twoCodHcMbWKi8gAw4AF1d/Yw5OGdvCjnkpSm/jueeew65duzBo0CBcvO9MVG+fhCACiCKGb/5mPt4bvBOnnXZa6oYURbGmTwdnALjrhWux8ckQ3nvqAErHtAGBAIZ9vBVHnJaLs6DZ10rfIRAIYPfu3fho84dQ23QNHMTfBhbiDqxd9zuc0e9zGe6hovQdekVwlmTZUnmM+mbn5eXhxIuBEy8GgETmbo6x56pNRq9kWyYGGaZLxFG4DGHTbGpT4xGK6fJ+FO6c0+9KZGHO8MLGJ5xKa3QZ0kTWNNBZdqYyMTUBoVIyN8wiuab27NkDAHjllVcAxO+LabgcK5vuQy1uRwUmoQa3IYxbUI3J+PDe4/Djtx5FfX19yra56ygd8p/kGpfce1w/ueUpOfwyp5HIzqYGHDa+0ibDZn6YJh1aR/L84p6NkkxyUzOrdNMrgrOiKPZ8YcsnMA/fwgCUIYxbUIs7EEEbqjEZFZiE2PoYfnvkM5nupqL0Cfp0traiKB2cv/VUOHBQgUkIIRcRtCGEXFRgEgAggABGNA3McC8VpW+QtW/OEvnVxj+ayprcEpNUHqUew1yGqak8apo9mOizTXaxjdTEyYKSYyzJ7pTIhfRz7jykY5k97pjQMr2Odu7c6ZX/+9//euUdO3Z45bKyMq88fvx4r3zkkUd6ZXoNSoYD6DEZMGBAp7ab340C9UANbvMCcwRtqMFt8TdnJwZ3fAilpaVJ2zM9b34hyb62yTCWGFjQ9ul1bSqPSu5dvyRjrn5XzT5Ms9Elzw4Ov55fkvo2WfY2ZG1wVhTFX5466SU8ueHPqDw4xkzHnF0AR372aOwrPpCyHUVR7NHgrCgKAOCh9x/HC3gBVQcDswsXXwqciceDz6Cy7RZ8vPHjOBknZ7qbitInyNrgbLo8makMQuXrvXv3emW6vB6VFIcMGeKVOdmPIlk+kstONMlmNl0SkcM0s5q2STOQuf7QY2nqWWwqyUn6bJoFK4FeU1u2bPHKf/vb37xyfslf8cmJW7D1/WI889wJ2L83npl91llneXUGDRrklWkWNzUq4a4p6iU+atQoAB2mIo2Njejfvz9GH30cntz4GjaO2omto/biXFyEMf85FrFYDOeee673PYCX1bnz1tLS4bhHZ034Bbc0pOTakWRT25jxUCS+2ZLvSowwTIf0upqdbDrk49cQh81wlI2nv5qQ9BBWr16NYDCIyy677AN/u/POO1FQUIAZM2ZkoGdKtvPss88iEAjgtvvexaixW5G4z91vv41vXzQKm94d0Ck4p4tLL70Ur732GrZhP7aN3t9p2tDXvva1tG9fUZQONFtbSDAYxKpVq/DDH/4QTzeUYtH2I/DbPf1QeetPcNttt6Ul0aU3UVdXhyVLlmDPZgd/vDsXv14QwvoX4sds8eLFqK2tzXAPM0cgEMCzzz6Ln9/fEZgBYFkt8Mhv3ke//k2Z65yiKBkha9+cJdm6Nlm2VIptaGjAt771LbS2tuL2228Hdo8ALgrj1/dUAw+uAr5ahf4XXYXGxrg5AzWJkCydR5HILKmynLk2uGUTue3b/MORTNZesGABfrUghGMRBgD8dqmLphNuxBOvL0BFRYX3HVPpzRSJJM4dB1PTFa4+zdw+/vjjMfZDb6OuchfgALMqgKU1QF0YmFcNzLjhHbz4tz9gw1sTP7AtzqNb0oeEJH788cd7n1HJmh6DRGY30HnYhsrkksztdEjZHFRypyoA7afE11ySYUyRyMKmUqzNEoymGeCp7jPTNiTHzFRetpGyOSQZ+pJrxC+yNjhngmO/MR3YNRx4sBJ4eAHQHgG+Wg1cVIHyDS4+U9aEYaHUDkJ9ke9dOhsPLyrAm6gE4OBYVOBN1OLN16tx1bfmY968eZnuYka59Fv9ccSRu1AXBpbXApFIPDDPiq/FggkT78f2949Hc2P/zHZUUZRuQbVYA56o7w9cFAZyQvHAnBMCLoo/PV04eKmh+94Kso0d6wI4FmEci2q8iTB+izy8efD3Tw69IdPdyzjDRu7DrDAQCsUDcyjUEZgBIBCIobh0B9+Aoii9iqx9c+YkWhsZiUIlsYR0N76wDbi3piMwt0eAh2q8AJ2Tm4O8vDxjaV3ST0oqsw9O8pccJxuphpOggsEghh8NAC6ORQXeRi1iiCCAEI5FBfoPaxINO0gycSUymE02LXfs6fXCXZvUqGb48OFe+WMf+xj2bN+NB3/2ay8wRyJxaTsRoF03gGFDTsOgfkM6tSMxfuGGaxKf02GYkpISr8xlf0uMTyjpyGQ1he4LJ/9TTO8PUymbQ3Ld2UjcNtJw4nrxyyjFBr+MRCTPWL989k3RN2cD6h+sAx4Mx6Xse1rjPx8MAw/VwIGLk0sjqRvpowwY6eJrVS14E9VeYI4hgjdRjY+eq0MBqxZHUFcJzKsCtrXGf9aF4wE6FnOw5Z1ZaI8MSd2Qoii9Ag3OQm6//Xbcc/vNmHj5VDgXlcc/vKjcC9Bf+Mt8DM/TtZ8Px+uttXgTlTgWVbgQrTgWVXgTlbj7gcWZ7lpGefTRR/HII4/gggsuwISPnYH33h2JCR87A1+88HOoCwPfveiz2Lf9At+3uzOwBS/l/g07A1tSV1YUpVvJWlnbZilESVYulQ6HDh2KgoICzJkzB9deey22tm7FhuYcFOc6aP7oNfjD6AMoC7meFzKV0Li+mS5txpGsjqkcZurFbZoFn5eXh7q6OixcuBAVFRW44vJZ2L6uBcPGz8Kd97WjpqYGOTk5XlIYJ1lTJHKuRHIzXfKQy3Ln+sYtVTpixAivPHLkSEyaNAlXXnklmpqacGArMGIgsKiuH8YccRtisRiOOuoorz41HuH6Q687avyxfft2AMAfy36FO4ZXwnVicNwAvrtxPj63+8udMrGpxE2lbJppTst0iUsqldPPe4LELcnWlmAzfCUxQvFryVZTQ41U2zWViCVLNJrOXpE8M00zvSmmBiPpuK4dtzsXqPQRuh6uzViOZDGFpqaOeab0QUeDcGFhoVem00tMje9Ng3MqTPfbr+BMcV0XtbW1CAaDmDt37ge+W1dXh1gshvLyuCLBHTObtYsP17dkcNui51zSJn340/Fe6jSXCJhA52utX79+XplOZaLBmQZNeu3QY9jY2OiVy8vL0ZrbjH/cdA9chzyQ3QA+NvlSlAb64brrrgPAB2duMQ9JcO5pfgBccLZ5pnBIpmSZBmfJ9CXJvSLZbqJsM95rk4PDfc5d95KAbxqcJc9B+mJnQ9a+OSvZRSLwJrvZ5s2b1yPeqPoCwWAQP1z1YwweCAwh2eDbamO4d839uGz61zPXOUVRPLI2OJv+J0kxzeilbyr0jYD7j1eSGWz6H1tXJ9f7JfPY/PdL4d5I6VslfXvk/iM1VSdMrwXujV3CoZnqyfpD30rpvtA69HPO7IPuOzXaoO1Qtefiiy/Grpbt+Fn4lwDiAXpHDbAzDAyuBl4u/wVW7G3C1e/VdHrjpe3V1tbCbcrBZZ+9HhGnEfufL0HrhgIM/2ITHvzPMkSj0U6Ob1zWd0/4h4w7P/RYcpjOGJBcp5JhKNM3QlNZOVUd7tlrcx/6JZVzdbh+2hjJpJusDc6KonSNj1w/Fn8YFQ/Iu2oBNxIPzIk36af7/w5f2PV1fAKfSfr9pjcL8ZOnluG9nwzC+SgHEH+Q3f9YNR7BzZgyZUo37Ymi9F561gCQoihp55VBT2NIGHBC8cDshDpL3HCA/xa9nPS7zVsC+OSfl+ACVOMRhPEo4m/Ij6IGj6ASF6AKXz1uZjfshaL0brL2zVkiyXAJD5J2KDYyjimmpgipSIcXsKnMy9WnsiAnz3ImKlTmNZHkpHVsZG0KJ3FTyZh+zsn+nNzJHUPaJpWVi4qK8MmGL+CPtz3rBWY3Epe2vQDtAhOciZ2SHBPLXTasywFiDs5HvPIjCONx1KIdEVyAapyPCux9eg/crye/jjhDh56QKMYdb8nSrdyzQzLzgMPG5MR0+MBEBrcx95FsX4Jk2VxJ0q3Ej9406c4vMn9HKIrSrby1ZDt2VgKDq4APt8Z/7gzHAzRc4MwDF+OYyElJv9vehHglAOejAjkIoR0R5CB0MGC7CJa1Jf2uoihysvbNWVEUc+6++27ccccduOqqqzDqy0V4fftz+MSlZ+LvO17Hg+GHcV79N3H9tQvZ7zeuz0VijPlR1HiBuR0RPIoanI8KRPfnst9XFEVGrwjOphP0bWQhU4lDIkf7ZRSSrC8UG5nML7ld4k3NzROkUjbFryEFToL2C042pftuui8S6ZtK6MXFxZg1axamT58ez+JunoKc/Bx8fS4wJn88Ak7Am52QbOhg2GeAf8PFo6jFIwh7UnZ8zDkMwEX1eVOQn58805vCSfKSueTpxuZekcwZlsjmkhkG3DGU+ANw/eGea8nmOVNMPRIkSNrk6vs1LMCdq3RndGf+LlAUpduYOZNP1po2bVrK9ZYHToji6Q9X4JE3FhwMzPH56wlJ+xFU4sOvN6Ly4ko/u60ofQ4NzoqiGDHkrAOYdNJMXHLUtQiW7MS+F/LQVh9E9Ten4MOvN3Z6m1MUpWtkrX0nZ1TBwckRnH2fxCpSgml90+zBVNuSSNOmy2/65TUrsTCUZE1zMhxXhyt3p5zK9ZMzs6Fw0h0nrdLs90TWNS3TY8AZn1Boe/SccBnoppnyXBa3XxmxkhkMFM7cxa8+SI4Pd57p+aRWqnS/qBoi2V/u2kl8lzOV4dqg2AyVmQ7zSYYRbPzROfyy79RsbUVRFEXpYWhwVhRFUZQeRtaOOZuah3A+zlQW4iRlKlNw0qdE3pFISlyWsIlPNCfncIYInJTNlTnJUtJfycR9m8xwm2znTMFJ2RJZk5Oy6bmmZSpTpvKPlgwjSORrCdx+mF53HHQYjO4Xle5tVmczlURNZVmuD5Kyqbc1ZwKUyoRE8kw2/dz0u5LnrY2UbZoBboO+OSuKoihKD0OD8yH8peAO3DLgQvw5//ZMd0VRFEXpo2RttjZdBk+S9Ut3s7m52SvX19dj1apVCAQCaFxyD5pz9sYNkFygsH0ACmZdjtzcXMyePRtAZ4lbIr+a+lmbSsBcpnUqJDK8jYeuqaxmiqkEReGygdNhPEKhx1aSlc1911TKpsM49NpPSL20DZrZy2X50uNEDVQ4j3CJh7ZEsrTJ4qayNufRLhkOokiGIzgk97ZE1qbnlnsOcu3Ta4F+l/OtT5TpObcJHyZDdYf20eb+54ZKTA1MuGuELitsg745I36QV65ciX/U7U04EwIO8Pe6PVi1alXaH9qKoiiKQsnahDA/mTJlCp4vuQ/PVqGt7gkAACAASURBVO4GHOAjFcCrNcCrlcBpFQMxY8qMTHdRURRF6UNkbXDmJrlTTLJdT503GAdyd+PVMPB6LRCLAB+pBs6ddhLcZrNsR5vJ9Vz/KZyUnSxbm2vPNBOUw1Sa4r4ryaDkZESJzO6XqYwpplK2JCtbstQmLVPpkxpVJMpcdi4n/3Fe4JL9oEiy9TkJnyKZ4UANUiicZC25Bik2sqykfa5v3OwRblt0dgqV+rntJpP9uVkfpmYqkox1iZRtul2/sqxNZ+KYorI2gP3Brdie/yY+UgEEQvHAHAgBHymPjzsriqIoSneiwRnAntwNgBOXshOBORYBXq0FNhe+kunuKYqiKH2MrJW1KZIlFylUqiksLMTIwHF4tTo+xvyRajLmHAbGtQxC3uwOScx0ArvEx9UUKmUlk6NMZTK/DABsJGKJRCQZpqBwx5vLKvYLLoOaqyMZBrGRsqmUSWc5JMpU6uZ8pDmfbQrtFz3GnPRqY2DCHRvJs4AeG1qm0D5z14vE/EJi0sFJt/RcSJaA5IZQJMeW7iN37hLtmC5xK/HZlsAdS87rnfuujdmMTfa4KfrmDODHy38RD8xV8cAMxCXtCTfm4uGFz2HJkiWZ7aCiKIrSp9DgjPh/3rNmzcJ933sOJ+2/CAMj4/D5+uvxyJUbMWvWLF0CT1EURelWstaExHTJSIkfMSdfcOYHkkNnulSZBJPsV9OMQtOsc9P9kMh8ptKRqb+vRKI1RSI1037SjGeuHa5NzmCEy8rmMnQTZfo9KmlSExJuKUlah+4TrUM/l8jFkmENU09pegz27NnjlXfu3OmV6TEeMKAjEXTgwIFeubCwMGk//coqTrVc46Fwn0skcWpCwsnaydqXyOSSZV/9MjDhMJWaJedEMmShS0YqiqIoSi9Fg7OiKIqi9DCyNlvbxluVk1kk7Zsuv2Yz+V2SCUlJtWSkjZctt02JKYON2YSpjzdHOrKyOXmZZkRTeZkzy+Cy77ms71SmIkDqDG1an7bHnX/aNpWyOV9uv4w7uM8l9xU9ZgcOHPDKb7zxhlf+5z//6ZXpMTvxxBO98oQJE7wyPVfccpMSJM8IzvdZck9Lltekxix+3x9cRrmpHG36LLX5nGL6rNQlIxVFURSlD5C1b86Kkg28lNOOv+dGcUpbEB93dQGVnsR9992HrVu34uhLP4qNo/cgpx5oKWzH6I398favfoVYLIZLLrkk091U+ihZG5xt5BGayUjlOlqfk3wkE/Al2aMSJPJVsj5wsrBEmjb1oJbIl6ZZkDZevBTTZQVN4TJrq6urEQgEsOnGa7G2KAo4DuC6uKSxFUfceCtisRjC4XDSvnFStsRghJZpJi4tNzY2euVEtjb9HoVmWdMMVM6Lm8IZmHBZwZIMfVNvenr86uvrvfJ//vMfAPGs7aeeegpPfe4t4PsjARfxVemqNwO/3IzTTz8db7zxBsaOHet9d9CgQSn7YOMlT+nq/X+4Opz0zRm5JEOSmW6arc0Z2Nj4V9sYhpge43Sgsrai+EwgEMDy5cuxdsXqeGAGAMfB2hWrsXz58rSMfyvmHPu/JwNVI4HKzUDN5nhgrtkc/71qJI765kcy3UWlD5O1b85+8vQTOXjmyTxMPCuCz5zTnvoLinIYpk2bhn/lxfCXypviD/yKyUDNLUDlSpw+/3pMmzQt011UAKwfuRO4dGT8HIU3A7VbgIgLVI8EKkbivcf3YeSW/pnuptJHydrgbOpZe6hZw5IlSxAMBvH6kzfi9RfzADh48Cf5OOHkVhx7ejmCwSDmzp0LwM60Ih1ZfKkmxafbHMGmHYppJrlE1kx3BiWFO87RaBQXTLsWf8lzgfBKoPZWINIGVE3DBZMmI9YcYyVxiZkJJ1/TTGwqXzc0NHhlasCxbt06AMDzzz/vfUYlxYkTJ3rlIUOGeGVq0EHhPJk5SZ7WsVETTGYyAB3HeODuoriUXTGyIzCHnPjvLnDU9mEoLCzsJO/bzO7gPvdrWUnJcJpEQjdBYtwkqS95RtgYEpmuv2DqfZ8O+qy+FgwGsXjxYvztxSWI/+sMAA7+9sISLF++nJ32oigSNuUACE8GQrnxwBzKBcKT8V7W/jvc+8iL5nRI2YnAHHHjvwMobfTH6UlRukKfDc4zZszAaR+rwH5UYh9qAAD7UIP9qEQZqtDwbmWGe6hkM0NiTlzKTgTmSBtQc0v8c6VHMGhvSTz5K7w5LmW3fiL+M7wZqN2M3f0bUzeiKGkia/+Pl8hLXLZr4vNPnzwT/34pB/sRxn7UAoigDNXohwr87ucuvvb9Fpxwciwty4SZLq9GMZFuOTnHNBPUL19ryXe5LE6b5Sm5Jea45QxN26TSZ2FhIbYuWwYsWglUT+sYcw6vxJbmfBTPnNWpPre/XFY2nWFA61CJm0rZu3fv9sqJTGUAePzxxwEA77zzTtJ92rJli1c+++yzvfLRRx/tlenxozMc6FCQxGTFVEaUyLZU/SotLfXKJ5xwAgDggQceAO6NJ3+hYmT8j4mf4c3Y+/33cfI3z+2UoS3JJLbxaDZdPlQi3Uoyqimp7i1JH/1aitGv5wvXBw7JjJF002ffnAFg66Zc9EMYQAhABEAI/XBwzUg4eOX55IsTKMrhWL58OdYsWoLzbpiJQPlkAECgfDLOL5+FW+sWYdmyZRnuoQLEg8A555yD8qFX4XPPfwjOQVXDuWEUTpt8FvIjev8rmSNr35z94HPnt+B3TyxFIjADEexDzcEA7eKkTyZfiF1RDkc0GsWcOXMwY+oMbNwewYacGI5sD2Dc9XOxLJqjS5D2EC6//HK89tprwAHgi0+fhDP/fTx29WvAoH0lOO3LH89095Q+TtYGZ4kkwslpifrrti3BfixCGarQD2HsQzX2IwzAxXcum4eTT8v9QPuSCek2cpepN2yy9m0ylk0n2fu17BsnWdkYD0i25RdU7qyqqvLKx7mFOI7USZiPcDKlxPCGy+imcjeVuOmyiP/4xz+8ckLipt+jvPTSS16ZLpvYv3/H9CIqF9N26D5xMiX3uU3mPoUev+LiYq/84Q9/2CsPHz486ba4faTDEZz3NQcniVO4ZwH1BqdDFvQZV1RU5JWpaYypyYnJPW1quMIh6aOpIY1Ezjdt38SsxZasDc62LFu2DIsWLcK8efNwzPBp+PNjrTj6wzPw3Mvt+P0fK1E6rh3A3Ex3U1HSRnt7u/gflXXr1mH8+PFp7pFyOBYvXoxgMIirrrrqA39buXJlp+mfSvbTZ4NzNBrF3LlzMXPmTADtuPCy+IPqGlyPpUvbVXpUej2O43jXebAEiDYc/IkQ0BABSg7+RPqtCpXUBINB1NXVYVckgjNmTkeR62JzKBePLluBR5Ytw/z58zPdRcVHsjY4m0pfNJM0Go168mIyaaK8vJxtx7Q/NhKKqaycrB2uX/SfD25Ot6l3uCl+HQOKxIQgHXIU3RaXAS7JxDeFk4lpdjc1Hnnrrbe8Mr0GjpwBIACsCwNABKj+HBBzgRv/CiBuavLaa68B6LyE4siRI5O2J5Gsuf0wRTLkQ7PHqUTfr18/r0z7zPmB21zvkuxo7lg1NjZi0qRJeAEx3FW3GHeVFQHlc4HaRcCixUBVBQZcN9UbzuDWBvB7mKurGd9dqS/ZlkSql6wxwD3DTYcybMja4Kwoij3BknhgXncjAPo/WtVfgagL3PhZYPnfceDAgU7jtkr3szUYwB8WVAIFeUC4Oh6YIxGgOgxUzMNs18XprW0YEUtv0FC6h6wNzpL/YGxWEzG11DN9E/WLZPslecs1dUCzmXtq898sRbLSDdc3DtPVzSSfS9q3UWM4FYCW6fmln9M3KiAuZSMAOEHAjQIIHtxO1I2XAw7QEEGgJM9TBGyuI9N59KYJYdz1zs1JP1RRS8A9XyTJm6bzfTnod3NycrAplIOY4wAV8zoCcygU/x1AzHGwKZSL0W1R35KnKIl955QEG3tdydu9qW2w5Lvc8KXN/HG/6NPznBWlrxMsiUvZbhQIIBgPyonAHHWB8F+AklCnjGUlM4xtj8JxXaCmriMwRyLx3wEEXBdjo/4PnSiZQYOzovRhChpKUtYJNOSlrKN0D25NXVzSrg4DrfvjP8PVQE0drm6KqKTdi8haWVsiX3ByhOmgfjoWRqdwCQcSUkkrpglppokZpqv0mCaTSWRKSf85y0OaONXU1JT0u3TOKLdCkam0ZpMwwyWf0b7l5+d7ZZoANWbMGK/83nvv4UC0ATNQjZWoQhRReAPP0Xh5BCqxBWEEg/0xevRoAOhkZ8nZdEqkd9N5pbQOtS2lbXLnh5P8JcMjtA90H23kVw7uPBcXF+OmpUuAmlpvjBlAx89wNXLbXBQnmUol8V2gcPdTYt9NE/z88nqQDI+ZWrxKhtm4c5KOBE9K1gZnRVHsKQv2RywaQxRRBBBEDIlAFAQQBRBDjlOW9sxUJTX92tvhVFXATQTkgwTK5+LcSDuKdPpnr0KDs6L0UXJycnCgvR434UZcjxsRQADLEZ9iOAKVAGLYghsRcAI44ogTMttZBXXz5uO4XAdTXRdRx0HAdXFNSxuubIli5PUzOqklSvbTK4KzRPrgVn4yXQHJdP6bRHKVSH2SDOxk9p0cNhnuppZ9NlnzFJsVfmiZ2kzu2LHDK2/YsMErU9l01KhRXnnIkCFemU4tsskk5c4/lVCpTSfXPs08plaOgwcP9sqf//znvfL777+PdevWobi4GD+N3YHtTVsxIHcgmgBsaQtj7BEnYFzOOKxfvx65ubn47Gc/C6DzMSgsLEzaX4mUTeHsTOl55iws6X5TCZ9K7jZDR5ztps2cYYpk3m1iX34A4NyIi3UOMN51MNIJAQUfbJ9bkY9ui5uPn8r2UjKkRMstLS1J2+OGIGyGBU09JrgZN6Y2wOnI3O4VwVlRFHNc18X48ePR2NiIhoZ6FBcXo82JIBdAzAkBwUaMGxe37Ez3+JoiZxQcjDoYI1zocENvRbO1FaWPctRRR3l+2SUlJZ2UgLy8PO9v48aNw+mnn56JLn6AFStWYNWqVUn/dsstt2DRokXd3CNFSQ9Z++Zss/ITrUOzdamUSb9L5TEqxUgy90wzNE0zQDlJxwSbzG2J/GMjBZlKgZI26YpNmzZt8sovv/yyV6YSKq1PJU4qp9JrxDS7X2KuwsmRdLsUei3T7Gra/4T0ffzxxyftC7XmpKs3UctLKmvTe4OTuOn2aR1uWIgOQezduxeRSARr1qzBpr37UHz9HLxXUISzG/fjv7fchLvuugszZ85EY2MjgM5Z9pyEa4ON6YZEiTAdEqF1qJTNyd2cvG+Sbc7dz3T79Frkjg29jk2HDiXPAomhj6S+JFPdL7I2OCuK3zz22GMIBAI455xzPvC3n//854jFYqiurs5Az5QEV111Fd4IFWDtyuXA8DHA7Ar84Ud3A3fdhSuuuALTpk3LdBcVxRc0OCvKQQKBAB599FHkDFuPsy8fhvzh23DgzQ/j5z9/Aw888AAuu+yyTHexz7M9mIs/37gUKCoDFoSBpbVxl6z5VTj665dkunuK4htZG5xNVxaiEgTNHqyvr/fKVMqk7ZeVlXnlkpIORyUq40mQmHdwcg2XSWiSrW26chaHqe+4RC6SyPM2q+tQqORGy19ZtANFnwLWVr6JvDFv4uIw8H+/eBNrHwAuueQSfPGLX+wks5pmlXJwXtX0mNBrjcvcptBsbQptPyFJU/maQqfm0PaoXEylfVqfk7jp9jmJmzMbcV0XG3NyAccBZld0BOZQCJgTxvN7tuN/A+lNXOOGIyiSa4E7z1w7kmEtrn1JmyZDYqb3KtcXSda8qVGJ6XNN8vzi+pNub+2sDc6K4ieRkjdRdMK/cPGJABxgbRh4aAHQHgEuqQIuPmsgsCllM0qaOaItArhu58AciQCLqzHy298C8tRqVOkdaLY2gFWrVuHmm29O+rfbb78dK1as6OYeKd1N64BnkfhH+OIKICcUD8w5IeDiMIAxz2a0f0qcodE2jK+9IS5p31AN7GyN/1xYiefXJL+HFSUbydo3Z9Ol/rgM0IaGBrS3t2PNmjWor69H+Zx2DO7/VzS2DMeq1Rtx661bMG3q9zzfZS4DVGJyYCrLSjISk0k6NuYeEiRmAJL+2picmJq1UKgUO3ToUABAMP9IJJy1f1XTEZjbI/Hfv/Xt49Fv5MhO04388kHnzjMn9VL52PTcJfPiphnXnAkKJ2XTOlz2uiSLmyvT/R44cCBWrlyJdcuXA/Or4tI2EP/punhuYSVuLS7AnDlzPrCtdEiQ9Hrn5GXToSlTOJldYvzCkWrGiOlsBM65zNQAynQmi81SspL6NkNZErI2OPvJlVdeCQBYs2YNxowAwvOAFas3oG4ZUF0BlM/5EbbvHYf9jV/NcE+VdFF64AxscWvwq9q4pH1JdfwN+lc18d9L3nfx3csz3UslFothxowZWDdlKh523fj4s+vi4mnTMaZlP7s+r6JkGxqcD1I+uw1DBwCVtcCCJfFhrOoKoOLgIi9D+1egsWUigIGHbUfJTkLtw/Dw5E9h7Zp/xANzefzzi28A8ndPxI9W/RxOtAjhcDizHe3jTJ8+HQDQVL8dlzXtw4uhApyKKE6KtQFTp6J///4Z7qGi+IPjZulyM9QYgoMzHqEZ2rt37wYAHDXqIhTkrUNe/448k9a9ndvbvPt+FBaf7/3OZWtLJsWbZiqbZEj7dUpN+2IjI5n69XLtm2aMJwwrAKC6uhpuThN+MOtMONF8xALNyG8/EiXBMVixYgWi0ShuvPFGrz6Vejn50nT4gjOSoMeZZjDTMq1Ph27ovULLiX7S/nJLMVI5n8rgVL6mMj8na9Myrc/J2nS/6T5xyzhyGeN+wZ0fCu0zPd7csaXXkWQ5W8l9wH1uarSRShI3XXJX4k1uKmX7dZz8qk/Ppw365nyQpubxWLpiXacE0JpFHW/OruugrX3M4RtRsprEWxlaD7khg+RviqIo3YBmax9k+coNqKyNS9mte+M/wzXxAO26wM79CxCNDU/dkKIoykEWLVqEpUuXJv3bsmXLsHjx4m7ukZIt9Jk3Zy4jtqCgAGtuXYSbVr7daYw58TNcAzS3XYPpM65AWYj31jZdMtB04jyXDZqsTVPJx8b/21TitvHilvSNa5PCybWcHCXJKpYYiUj2kX5O25FcXxKf5WTXESe3Svy8ucxtTr7mpGzJ/nE+4nS76fDQppgutQoACxcuRDQaxcATpuM3/yjG8Ue0wtlQhzvWLMWMGTM6nR/JOeewGSqTfJ7s+cItuWhq1sJhM3MjHW3aePqb0meCM0dJ4VqUFPywU2BOUD4H2N94Bdqjyd2WFEVRDkdiOGTx4sXAuEJgbBjPPLocWL8UZ188D9OmXZPhHio9lT4dnAPOFgwuK0dVefK/NzRfislT5nd6u1IURTFhxIS58cC8vhJ4dwHgRoBx1Xhyfzm27tmG0tJM91DpifSK4MxNZucyHxN1cnLWwXF4L96YczoKCwtZ0wcbKcPUu1Ui3SQ+52QYyXJnkuULJTIPxfQ4mS7jRjHN9OYkV4qpuYPpeaOYGtVw54iT05PJvjRjneuLJPuak5clQwGmfupcm+nGNPseAH7/z3xgbLgjMDshYGwFXBfYuDMXx47t+vXCIbkGTZ8TiTqmz4iuZoIfro9cHUk7FNM1ACTHzC/6dEJYLFYI7pi6roP22Ce6t0OKovQ6Bpa2A+9WdwRmNwK8WwMHLo4cmnoRE6Vv0qeDcyDQhGT/vLmug4bW5Yi5I7q/U4qi9Cqe/7+lcUl7XDXw+db4z/VhDNpThRED0ruKlpK9ZK2sLTFl4JaqS8jUDo6F6wY6SduuG8De5kcRzD0FecEPflfSn65mQR5axyZ7MFUbkgxhiQxumr3ql/QlaZ/CDXdI2qffpRmpXPYw1w7FNItfIgfTch6zOhOVoRPb4iwvuQxtznhEYiril6lMd8rapsYZ9DisWrUK655ZCIyrAsYe9AIfWwHAxc6XKnHLLRFj1znTa18Cl2mdbLt+LacoyfT267nAbZfCZZVz35U8823o02/OLkZif/MSuG78ZnLdIBpal6E99rEM90xRlN5ANBrF/PnzMfaU+QASwcLFkafMx7x589QLXGHJ2jdnv2huuxSt7acjJ7ABrjNepWxFUXxj3rx5AIDZaMQ9TwCP/ysf5368BZd/IQZgVmY7p/RostZbe//+/V65oaHBKzc3NyNn2zbkbtiA2PjxiA6Pu3qVkvkKXPa1RDaxyTzkkGSYd3VbNhP0bS4NiZmGX/3xKxucMw+hQyUUTjrmoP2XvDFJjg+3bCE1tuD6n6hPs7VbW1u9Mj0e1KCF84KWZGhTTKVP7lylG4mHtsSYwzTT1zSbWrJsLde+ZBgnUeYMZiSk+/6XyNoUuq/0+uVkdslQHPWet6HXvDmvWLECgUAAswYOwJBwBZxYDG4ggF21C1C3fQdycnK8dV4VRVEUpSfTa4JzIBDA8uXLURpwED44tuPEYrht/nzcFHMxd+7cFC0oiqIolLq6OgSDQcyePfsDf1u8eDFisRjKyxkXJ8WKXhGcY7EYrrvuOgQ3bULl2rVwHKDCAWpcoNJ1MfOrF2PmzJlJv8sZN/iVfWeTqdzVifDpWBLNxhDD1AfX1DiF6wMH1x8qZXHLH/plPCPZR5thFolxSmIf6f5JDCbo55yXtakJhqlPfaYwNbyQyNemJhem9w3XN2nW8oIFC7A/tg/jZ4/G7uB2nNl+Hv5v8VNYtGgRysvLvfo2JiEckmcyvW9Nrx16/WZqWJOjVwTnBDM/9SkUPbgWYReodYEIgCoHuPKTn8x01xRFUbKOmTNn4o2cV3BL7a0oKgCKKoCbqm9C4yJg7ty5qkimkV4VnPNeeRlhB1hwMDD/f3tnHlhVde3/771JbibCmCCTOBVRW6lYO1fbV8WBPp+vVaF1qqIWFRkFFUhu5CYyCIqC4NRSRZ8+a+f+Wmutlmp9bdWHPmitaK2IzHMg403uPb8/Tu7JCt7NXYt9bu7g+vyTnZNz9tlnXDnfvfZ3hwCEA8D+9eugAxYURVFkbA9uxV8iz6I8BDSFgaZ6AFGgfB5w3pSvZ7p5eU3OBmcqR5SXu7NGORdcgMgTT3iBOQog4gBTzh/bLbOWI62aZEHOYHmTFCOVxDjSSrJ92Xg7UzjZqFKPbo6UKfWy5uyXwtmXaX2/MO2LZgZzpt2jy6PRqFduaWlJuj4dqZAs09aUuU0nfzFlaEv9iykcSd6P0QtcONn00v2a2syZspOzX869L+1u2hh8Dwi4X8yJwIwQUB4G1jb+FZ/Fl5Luh9Ne0zom0xeOIQ2Fc79wzpm0W84v8sqEZOG69ah1XCm7Lej+rHWARevXZ7ppiqIoOccxseMBB2iqA+hXT1MEOL3j8xluXX6Ts1/Oh7JkyRIsXLgQs2bNwqRPfQqNa17ElHPORcv69Vi4cKEOpVI+tmwNtuH9wlYc11GC41GSegNCUXAHigs+RCFOQgcGpamFSrYyKD4En6+5AL+681mURzq/oCNAUy3wXMuL+Gx16i9n5cjI2eBM5YWysjIEg0HU1NR0BeCLL0YRgOqLLkJhYSHi8XhK71mOdCvNSDRta8owlMraqbCRZKReuZxtpTKSNEtVmvlqWp/Ky6aM5HRA98WRuOl9FIlEUFBQgGnTpuHx4Id4vlcD+sYK8fM++xGvfwboiGPpzGpc3uoa8yRk8A8//NCr45133vHKw/r+Dmd96gkEAw4cJ4D1Wydj8/7zunURUZmc49FtMuUwHSstm8xs0iFr+5XtzMmgNnVZcO5ZTrcMhfPc0+u1cOFC/GrBs5g8ZxJGTBmO3Y27cPa08/Fc24uYP38+ioqKPBc0my4803KpDzbtIqD3mmk6U+mIAUq6Pd1zNjgfSmKsXbKLdvvtt2fFMAxFSScFBQVYsmQJHinfhobabwIBuHbO9c8A4aeByHjM7PUu/i3aH0Piyd3NfvrTnyIYDOKycWd5gRkAAgEHP//xcry3axPm1S3tuYNSMkosFsPs2bMxa+YstLe5gS8UCmHUrM94f1fSQ94EZ0X5uDNt2jT8rbARv533IFDQAdRc2i0wo+ZSxAC8X9BiDM7BYBA/+clPcEzl/+Bbn+/6qqhbBtQudXD9NY09dDRKNnC4oVKzZs0SW9gqfHI2OEsz60yyoE3Wp03WskmykkpTydps+m+WU7eNEYtfxiqc5ZxMZhtThnRLVhyo/MaZzs5xHMTCFwNl+9yAXP8TINrhBWYAKHCAExy3G+jAgQMAgO3bt3t1LL3tNYwaDtQu3YY+ZUB4qhuYw/cA86YDx486G42NXQG6f//+XtkkQdP7kWaUt7a2emWaGU7rMXl6m66PX9Mm2kw3aPJoN7WNelVLu7I43WyctpnqpN0WiXZKR1BIp7iUTltL7yM62oB2ldB/IhKjewDztK82Puh+kfk3kKIovnF0NARUXwqECt3AHCp0fwcQdIC7m0ZiSDx5UlhVxasYVrUJ4alAZAZQuxQoPtENzJEZQM0UYGj/f/Tk4SjKxxYNzoqSR7QXwJWyE4E52gHUP4NzGnvjpU2fxBVtg43bDu3zChIfQjVTgFAIiEbdnzVTgEAAOH7wqz1zIIpyBNxzzz1YsqweO4v/B3/vfTfWDLoY7/R6BACwdOlS3H333RluIZ+clbVNMoJpCjOThGOTwcxZR+qtS+HIQalMSEzrcjJBpXCyHU3Xh7aBSp8mSY7jd83JEuece47xTLox7Zeeh4qKCrQu+ilQ39XHjDq3z7lv61E4+ZbabhJqolxRUQEAiOIEAGsAuFJ2IjBHo+7vNVOAxugIlPZPPWUkPX9Udty/f79X/uCDD7zyrl27vDKVUo899livPGRI11zrnGlIORI0x5eZwqnfJqPb5PUuRfK+ONxySuKc25jBSJ8907am53Nf0Xo8tvgFvNP7YYypBhAA1jrXPgAAIABJREFU9pW8geWRe/HrJS2YPn06q/uCwjln6egGy9ngrChKd+666y48M/8+DK39LrZUX+gurL4UQ2PF+PG8ZRjhlHvDXpKxs/FcnND/B6hf3l3KTvQ5Ow5w2pnn45M63FnJQpqCWzFq0Ys4vwL4bdhdNqYGeL4e+O0dLbjytjMxeeLkzDZSgAZnRckTYrEY5syZg1un34pfN2zDC8X7cHZbP5w/5d+wJDo05ZdYW6wK184dhR8+uQ6RGcDcyW5Arpni/qxdCly6eQ0WjDqvh45IUfjsKnwVCDgYU+P+/tuwG5hjUeD8CHDWzH3A9sPXkU0EnHQbhKYJk3cwx9jAJK1K4cjO6fYANrVHsk+baQopNtPjUei1pQGFyp1UzrWZQo9DsmkWD0dPZnrT80NlNo5JQ6J88OBBb1l9fT2KClsw5Yav4GDzUQCAksLNKO71SSxf+TPEYjHceeed3vplZWVemZ5jup89e/Z45Q0bNnjl5557ziv/61//8soDBw70ymPGjPHKZ5xxhleuqqryyvRe4GRxm86TdPQAZx2O9MkZ6UG7Bmg9tJuCMweAtLsmmcxOM+vp80CfTxtDH2nXQeJ98X7o53ip4jpv+a3FbmAuCAF3tQHHNlyBMxruRO/evb116PmjcHzNTfcCfSZs0C9nRVE8Jk6cCABobAeicfclHI0ORD+nH2688cZMNk1RDkuv2HDXdCcAPF/XFZhjUeD5CHDbjadluokiNDgripIx/u+dX6PiqP049d8rUVLejub9JWh8vwwt+3th7dq12LdvH8aNG5fpZio5QEegyQvMvw27UvaYmq7fK9ofwpLrL810M9nkbHA2yVFUQqFlqW+qSbKgsgynTmlGIsfrNZW0ZuPVLT03FGlGtAlqGGCS0ExwZHNpVr5JpqT41VUixSS/UcmSnsOE8QgAz0yEHmtlZaVXpqYf9JqYZGRTFjSVzal8/cmrHsbeXzTi0Vqg7/AduLIzicdx1mH2OX3w+usNqKqqwpYtWwAAp5xyirctzeinbTA9n6YMXen9Ip0OVprBbJKdTTIx3ZZKtCYTGNP70eQ9newc0i4Lej5Mhh4mKdsmyz7ZNe8fOBHPRwL4ba3jBWag6+cz4XdxQscDntXzofvyq1vDL3I2OCuKkruUDV+HoaMaceynAQSAR8PuzytrgCfqgddebMDxI47Ceedp8pnCo9wZisHNY3D+vN95ATnBmGpgROtViLXnjhe4BmdFUXqc8uF/8wxPrux8kT4aBv6rHmiPAldHgPKC5F9iimJiwfTVaA5uxV9aZ2Bb8Rpv8pcT2r6N7864J9PNE5GzwZnjlS2duo1mCdMylWVoJh7HCEM6JZlJQqFSkslkJFmdNoP+TUglHKkBDD0mUzawjQe4jdkE51ik3so2mM4JlTKp8cfbb7/tld9///2PbHf88cd75ZEjR3plqekLPQfJJPG2LafB+eTL3QJ0IjAXhdzfX3qsACWtXRnA0meeI1lSOJKlKdObM7WltDuFytSm4zVla3Pkd5MBi6mLJvEepNdT+h6z6XYy7etQOb8cI3Bhx6+wo+M1bC/4CwbFvoBBgc8hMZW5zbta2q1hQ84GZ0VRcpfWLadhy1t9MPSUBgQCwON1XYG5PQo8HgGGH5PpViq5TFX8M6iKu1NbIjMpIVZocFaUjyn7yluws08TKveVol9TaeoNfObJW76A4z63Ewdib+LJ+Q6ujrhfzI/XuRL3v1+7E0M+2+PNUpSsIC+Cs0nmNQ0wp9BM0n379nllOvUYlXHoFHl0MDuVgqTTPpqgxgNU1qYyOx34nyAd8rU0M9FGOvQr41pav03GpckMRCplm84PrdPkYU3XodnM27Zt88ovv/wyAODNz+zBry/bBBQEgJiDYXX70P9nTTj33HO9dXv16uWVE/7bh+7HdP5oG/v06eOVTzrpJK88duxYPPfcc/jNb97A1fO6+p6vrAHgAI/WNmOg8yquuuoqAN27OEzdVNLryekeoV1c9H1BzzE9XnquaJs5Wb+mMsd0h3Ps9D1lyu5OZTJk6uLgmC9JR49wpr5M1sZDyxTOtJWm9aWjcmzQWakU5WPGgd5R/PrNF4D5/3QXFASwuaYfogPdF96f//xnvPLKKz3Slng8jrFjx+JbN/VB4h3oOMClN/fHueeeazX5g6LkMnnx5ewXK1asQHOgEGddNx1V8ShejVVgTawfznEaseOxRYjH45g7d26mm6koVuwd0Aa0BYDwO+6CmhFAQQBbZvfFr5etwT9eeR1f/vKXe6QtF1xwAQDgT4s/hcGj12HgJ99Fy4efwb63PosxY4DPflZ1beXjSd4FZyp3mKQPKkcljBgAYF1rIf60ahkebakEruwcqB4I4OWH7gdWrcSECRO6Sc3l5eVJ92Ujg1D5mpNZaZLBUrVFOqWc1HBBmqHJkSmlkpUpy1JqGGIj6ZskYCqDckYVmNbn7Itma2/YsAHNuxzgwRHugkSArv4EDr6yBf/4xTsouflE9NvYr5thCWeaPVPGL5V26RSQdLn7HF4INAC9hvQCOmeHpJI4NUUxybCcLh3O9aTP4d69e73ypk2bvDKVuGk7hw8f7pWTTdHJxcbD3lQP57ylknpN+/drSlrpO0L6nqJIvc9N7xTN1k4j22OF+NNV9wKoBFZ1WhVdVQOsrgNW1QIT5mHgVblj/aYoJjZ9vtMZqoYE6Pp/AtE4EDkRrdUjsH2e/y8bRVH4aHDu5MWWMgABNyADboB+vHPg5YQIcFUNXsYuXIuGjLZTUWzZ+sUO15wBcAN0IjCHgl7A3vmZzLUvm/nhD3+IUEsIN35xEso39kafd/pi9xk70TEmisceewyxWAx33HFHppup5AF5EZxt/KsT5Z0xInVeVdMVmItCnQHbwVmBfSgoSD7o31S/VMah8iWV1miGJMerNtmydE+P55fXOCcDlCOtmuQ8mwxwG+mObmvyR6bL/TKHoVnXVVVVOHF9A/5yUoMboOve7QrM0bj7e/UInLyxP3qP7hqNYDK74Vx/UyYzvafpcZu6pmiZ1pnKiOdw7TTdU7T7avfu3V65ZG0ZHlr/AAb/6GjMRjUCCODoZ49FzcrZ+MGeH2DcuHFGuZszPSFnqkcT0mfClPVv2jZVG/x613CeHxPS88SRtf2ak0CKZmsncBwAnRdt9SGOCKvrAADHB5PPIa0oucToNX1QcjAARN5xJe15I4C2C4DIie7vde9iwGa1zjyUysePwr3rVyCMCCIIYwHqAQALUI8lexbhmq9ci0suuSTDrVTyhbz4cvaDtztKAAQ6+5jDnpTt/Q5g/dVX4OzMNlNRfOHUc3bgtdfeReDmY+GET3QXkj7o188rAy68OmPtyzaKdhRh8P1HI4AA5sDt+oogjIWoRxRRhBHBt8u/g7/hjQy3VMkX8jo4cwwSEhnX3+iI4sW7I53JX5GuvmfSB72jbD8qamcnrScd3to0O9WUtZxKDpIOuDfB2SdH8pVKdSaZz5RhTpFKXKbj4kjiJjjynum82chstM1Dhgzxyl//+tcBuFJtaWkpPn3053F//C04iV3VjEDAAU7ccBwGDx7sbUclWWk3kskYSDoCwJRpbCO5mzjU1774/VIEnK7t5qDGC8whhDAb1Xjjc6+itLTUt3PlVzcLpyy5FtLRKJxnQDqqRNp2E35J+yprp5HxfVrROx4FJszz+pg9rqrGyd+bgypEjdsrSi4xbtw4nHnmmeh9IISxvxiOQOf7MxgP4MZ/vwYTLrkysw3MMuKlMTjknTAfdV5gjiKKBahDtK++HxT/yOsvZyl/ve0K/Ky5Ar9vPYDRBQdRGgR2xwtxTq82jJp5daabpyhpYfTaATjhnxXY278NZw05A5Wt5ak3+pgRbClAoDPFfT7qEEEYYUQwBzXe77uf3IUL7tD5pxV/yNngLM1MNMk/NHu0pKQE3wPwPbSjvT0hoTkoLq4A4K5n8pW1mYaQwpmSkFP/4ZYdbp8mgw5pprQ065RjuEAxXU+OVzInM5yzvskYhuKXKYK0a4DKdX379vXKZ5xxhlceMWLER+qg69Isb1MXjlTys8kW5nTLSCVUE/Q579+/PwpOLYQTcLDAqe8WmAF0/nQQ+d9aBH7rdDvHUnMiaVa56ZzQ7HfqDW56LqkhjGk0yJFiaqOpLSak7xRpl56NPM7JJJeSs8FZURSlp4gN6sDuyHbEajq8wOzAQQABOHAw6T9uxp6jd6oXuOIbGpwVRVEYNF7SgLEjz0evv/fGBvwdsVAHSreU4cCnGlD6lWJMxMRMN1HJIwJOOkxBe4Dm5uaky6XTDXLkJWmWM/3vmSMTcyRrk6RzpCYBfkH3aTLQ4PidUzhdEzZTQNrInZxzaOMfLG0zJwOcXhdaTvaVR+8tKm+apkQ90nvx0HWk96b0mttk99LpY+l7h25LZWE6xazpfpdmcZuMaij0WlA/9T179nhlKnHT0SADBgzwyrSrL5XELe3uMm3LWd+0rbR+EzbPLYXeCzZotraiKEoes3LlSjz44INJ//bggw9i5cqVPdwihYPK2oqiKHlMc6GDx5avQGMwhlGTvoVX+jbgy/v74F/LH8OKFSswadKkTDdRSUJeBGepjzMn05eTuWval0nKMsmyUr9mqVFBqvpsoNIonYrTVL/JSIIilXDTvS2ni0PahcKR6031cK4jbafpnCfMMjiGGKZzQz2oqQTKyfi1uR9tvKZN59I0aoFODUulYBNSP3jOtTVNT0jL9FlMyNc/qtiMx+/7NFB1IR4LPwhUbgHCY/HTh1YDK36Fa6+9FuPHj+92Haksm+xdxrnnpF1ENl2Q0vpNZanZkE12N4e8CM6KoihKd7YVtGJu5VuIBwDUjHUXhn8F3PksEO0A5l2IEd/6JrAvo81UDGifs6IoSh6ysajZDcwJasYCoUI3MIcKgfBY/KVfY8bapxyevPhytjG2sJEsbbyBpVOqUTgyeKo6bCRfikk+Na3DwSbLkiNTSuF0NdhI9DZZohxJ3GT8kdiWIylKDSNM9XBMRWzuR6n8T7GZApYjm9rUSdtmmm6UXqOOjg4c3RpCwAE8S/C633QF5mgHEPkNvnTpTSgsLBRJxqZnzHRPS/20KdJuKunz5pd8rd7aiqIoipy637iSduRCoG25+7P2V3hj2TOZbpliIC++nBVFUZTubCxqcb+aaWBO9D13/nwqvAq9YgWYM2dO5hqqJCVng7PNwHOpXMzZloNU0qEylcmHOJmsZMrypPhl4mCaDlDqfWtqmwmO1CT19JbKoDYZ2jbZxjb3fqp16P1CM3jb2tqS7p9mMpueGU43kuk+tbmP0pENzulGoHCuudRchz5npmMsLS3FSQVA0AHisXj3wNxJsHosrtk3HCUdwW7XkdafDJvRDqZ3h+kcSP3rpe3xaxpKzdZWFEVRWAyOlWLhvlNxey3cxDAH6JxYCwEHqN95Mi696ZxMNlE5DBqcFUVhEWzYisK97yM24HjE+wzJdHMUBt9uGo7TdoSwKdSK0ngQmwvd8c+fbq7ACcUDUmytZJK88Nb2S17iyBrplmKlGb2ppDupxGojpfol4Znq4UhQJmykLKkkajpGzn5NGeYmv3ZppnWyttFlBw8eTFoufvUJHPPSfAScOJxAEB98dQ72nPyfqKqq8tbp37+/VzZJoza+yRzjFmm3FmeqPxuJUzoChLNfznmghkCmeQioBzidIjNVNr5fIz0o9DhoFwrNTKf3fUlJSdL2SkayHNo26fvfdJ44RjUc9MtZURQjy5cvR1FHC+6JPYqA4774Ak4cx/xxPhb/YSNCvSsxffr0DLdSUfIPHUqlKIqRkv2bcO9Dq1C/tvsXZv3aOFauekI85llRUrFo0SIsWbIEAFC44w2UvzQX5S/XoGD7WixZsgSLFi3KcAt7hpz9craRGv3aFycjsSfl7lRSmbS9NpnvUrnLRu7krCOV3DlBxyRB+yWncTzgOW1L1W1hkhSHrh6HxSXr0Od0ILzWXVYzGqh7w/193unA1GH/wvZOH2cqn1NZOx3Z5Tb3HZVKpd766cjul3YxcTKYqUxNy9JnKNVy6bPNmV/AcRwsWLAAhe/+EvNO+Xsihw2R+x/GwjXArFmzul1Denw2cjSF0zVFSYcJSc4GZ0VR0kfJuy+gfMc6BOAGZMANyPVvAtE4EDndXe78/efYN/oytA0eldH2KvnDjBkzUNC0DXUrn0DR14Cas4C6l4DaNcC8rwE3Xva1zDawh1BNSlGUj1D27h9AvwVqRgOhoBuYQ8GugB0AULplbSaaqOQxs//jE4h8DQivAYrvdH9GvgaEzwJC21/LZNN6jJz9crbxX5bCMfIwYTP43Y/sVD+kK1toG6Qe1zYZ6+nI0KfXjSOP+ZXlzsnoptu2t7d75cT0gYdum5ADad0JOTp60hg4bzzpBei6N7oCczTu/l4z2h06Gzv2CyguLja2xXQOOFMr2lxPE6Y6bfzXTXCyh6XPts0zbdPFkGxdjpHIkew/OuhzqD4LqH8ZiMaAUIH7Be0AiPU5HvRKcQxsutVNMtlN3S+m6yOdVtIG/XJWFOUjtI08B82DPw0H3fuY265xf4bXApE3gMZTL0Z06Kcz3VwlzyjY+w7qXuoKzNGYK20HAARiLSm3zwc0OCuKkpT3xz+BW1q+gfBaYMr483H9Fd9GS6/BuPFbYzDjoi+idi1Q+8HwTDdTyUOWLluO2jWulN02F57EXfcSABy5CppL5KyszZF80+GP7NcAfM4UfH60wcZMQ9oWis2+ONIXJyNaKnfZtIdznm18mTmSIb2nmpqavPK+ffu8MpW7KyoqAHT3x6ayXWVlJYKDT8KsWadg8uTJ6ACwu/Nv064CAp+4D4WFhejbty+A7ueVc39Lz4d02kqpmQ1HTpcamFA4MqhfJho2PtGm85yoh9NNYcJ0Heh9d99992Hhz9/DvK+5UjbQ9TO8Bmj92f9h9mnfSblf07FypGyKX/7bUnI2OCuKwmPFihVobi/EWd+cjqEVzTiqoitAL1++HAUFBZg1a1bSbWfOnAmge1BPMHXqVC/AK4pfxGIx3H777ZhT9d9wGjZ638nVZwHRE8YiWlh+2O3zBQ3OipLnvLqpAq//v0V49LVKYFQ1TqxsweWn78K+1+/Fvffei1tvvTXTTVQUj9tuuw0A0ICZKPz7kyjZ8FO0DzwVHaO/hxkVQzPcup4jL7y1KTamD6Z16IB3U3an1E/XxtNVIt3bZLXTssn4QHoc0uxrTjvTsa1fnsgmOPuSTqNIr9Hu3a4AfcNTA/DsW2XAunrgzTBwWgQYVQOsiwBv1mLKlCmYO3du0vqoRzC916WZuKZtpVMlUtLddSDtQjG1wfSOkD4rnH1xni3TPUWXm+pMTFubDvMVThs53RE2715T2zjHS5+9Xr16JV1Hin45K0qe8n+bi9zAjIAbkAE3QK+rB+JR4LR5GPTl6zLaRkVRkqPZ2oqSp7z6QTG6ZbaOqgGCITcwB0PAqDB+/44//+UriuIvOfvlzMnElG5LkWbimiRgk6QnbQ8nSzRx7H5laEslM7+OT7qtCakBiM2UlBy51rS+jQGHaZ2ioiJ88YQYXNuGzuXr6roCczwKrItg7DdvNE6/l5Axufs33ZfSZ0lq3MPJ1pd2U9h4KHOMKqTPpY00nCzj+tA6JXK9VDqWHqv0HS59Pjn3r7SLwOY9a0K/nBUlTxl9dAcuPb0FgOMG5jfDwGnzgCva3J9v1mLrywsz3UxFUZKQs1/OiqKk5r5xDcAbc/HMm/fi0u9Ow6nnXY0/vNuAfzv/aux/vQH33HMPSktLNWNbUbKMnA3OHKmMIzuYMjRbW1uTrmOSACnS7E4TJmnK5AGc2JdUwpNmLHKMEmyMWzhtM60j7YLg7EtqGCP1TTfVI5W+6X6pscjwSncc84wZMxCPx3HtV5sAFKLsghrvfqbT7qXav9SEwsYr21QPR/rmSO5SWViarU2xuS8oNt7WUqOVZO2XPm9S0iHhSyVoThvSIWV321c+DKWS3qwUm+BM++Qofl00zk1HSbRfGnykL09pIPJr2AhF2jYbpPM82wwj4wQFzvmn8zLTZ4XWX1ZWBqD7PS09Dg42wVn6z4p0WJp0WF26g7MJzvFy3nem/dJ/QE0kPgr8GOJ5ODIVnG1yRSiJ58oW7XM+DB1bg2j5UxE6tuppUhRFUXqOnJW1KVK5yPSfH/3C2LUKaKyuBOIBIOig4s7dKB13sNt/VyZPYpsvS4qp/am+5KRfWaZ9Sv8j5dTvl8Rp8yUk/a9Y+hUgnQLQdA6l2aO0fipTm7KuE2WpBCrFr2xXyTMA8NpPDYZM+5LWycmONiEVMqXZ76blkux0ada89Bz4tb70fZspD20TeRGc/WTx4sUINBfi4ocWuIEZAOIBHJxbiUfeW4iC3l1+w4qiKIqSDlSvPYSCggIseWARVsXruy1fFa/Hfd+/Jy0TsiuKoigKJS++nG0yPak8Fo1GcfPNN6N9fxxLHw4DACagBqtQh0cQxvWYh8vfn4GODncKPjpTDw3a0kQkjrwkkVmk9UkTVTj1m+o0SZmc6fdsErykxyVNPqHYJNWZ6pEul8i+NhnlNglBUpMVm2Q5U8Y9R+I0ZcRzJF2K1HPb1H7Oe0d6b3IMZBLrc55V6cgQUxtN2/o1IsaEtFsuHeRFcPab7514GxpRgUcQxqOoRzuiuB4RTEANWn7sIHpVI0KnfXQKPUVRFEXxA5W1k9DyXBkmIIwihNCOKIoQwgR0ThyAANpeL85o+xRFUZT8Ji++nKWyhknaSUhEZRe04oHnl3iBuR1RrEJdZ4B2UPaFGIqKilBcXJy0HmnbpOM9U0k6Nn6xJvySjqQZ0aZx6By5mMKRxE2e6NJ6KNIMVqlkLc36T7Yv6bn06z7ya5wzRx43ydRFRUVeWXpe6XLTvcOR6E3tj0ajXrmpqckrt7S0JN0XHV9LyzbdDakwjS6gSO9L6XhtKX51WfnVHhP65ZyE729dgEdQi+sxDy+hDddjHh5BGKsQQfm4FpSMTj78QlEURVH8IC++nP1k6dKlWLJkCaZPn47rBt+AluebcPPImxFa34oVf6xF32MaMQMzMt1MRVEUJY/Ji+BMJSVappKVSdaislBpaSmCwSBmz56NadOmuQu/24RgMIg7MAMVdzuIx+OenO2XxCGVmlLJbBwTBBv5NNk+D7fcJsuSkx0rzTDmmEf4lRkqzUg3wTFdMR0jze6lRjuJdWj3TDKPbe5+OLKgXwYWNs+eTdeHqQ3U6EWalW9qD7Vg3bNnj1feu3dv0joHDhyYtD30+trcv6lGhnAyzU3PqtRwSdrdIV3O6XZId+Z2XgRnP7n99tsBdH+hJbjlllt0nLOiKD3OypUrEQwGccMNN3zkb48++iji8bj37lLyAw3OiqIo2U5zIVY8thzxxiAuKp+M9j9Woeiru/CjvUuw6r9/gAnf/l6mW6j4TM4GZ440ZZpphX79UjnCJO9xJA4bD12pUUUqqcyU4ZxqqslDsZmNh5O5KTU/sZH/pYYafsmvNqYLHEz3Jp1VbefOnV55x44dXjnxfAwYMMBbNmjQIK9MveNN7TWdM07ms1/dETYSJKerhCKV06XXlh5L4hru+e9ynP/4fWhAFR54LIwGVGI8wlj992V4Eg/jMkRw0dPV2DlyMyq+6UreNNObzjombWey8yM9rxTprG42fv0mpIZHtE7O9LF+kbPBWVEUJd+JbivAptv7AfEAxnd6LTyJMH6EO9GBKC5DxF3uAHvrhqH0SwdReJQaJOUDOpRKURQlS2l7v7BrAh4A41GDQoTQgSgKEfICNgAgHkDHpuQJfUrukbNfzpyMWypBcKaGM8kpnAncbbINKVLZN5lEY5IXbQbZm9bhSEocX+N0T9cmzda26crwK5OYcx5M93tDQ4NX3rhxo1d+7733vHIi6XH48OHeMlPXDh35QDH5RZvOpTRj2bSOjd+1tBsnHV0WHNONgoIClJ0QB4KOF6CfRp0XmDsQxdOo6wrQQQelJzgoCoVYiauce0pyvNJREJy2SCVrv55zU53plrIp+uWsKB8TVq9ejf9a8zv8/tQqbKwq7fa3p59+Gk899VSGWqaYCA2J45i7GoCgg6dRhycRxmWI4Cdow2WI4EmE8TTqgKCDgfO2oWiQGiTlCzn75awoiow/DyrGe0ueAD5ZCVRfgxGbGjBwfxsKVvwYLz31FL7zne9kuolKEqq+04yVb87Fk0+sxGWY530pj++0E34SYZRcuhkzL56W2YYqvpKzwdmUhUzHJ0szE6XSiql+qdmE1JOWkkwykkrpfmEyG+BIbKY2m2RT6TFKrzlH2rPxfebAkeUodL80W7uhoQH/7FeE9+66FugdBMKPAADerb4G767+IfDIE+h/69U49+SvdjMpoV1BdJ80E5heByp9mwyAKDb3qTQbnCI1npD6u0vvBdOxU3/s0gFFmDFjBi4/ahI2z+6UuYMOpka+h8qdexCPx9G3b19vfdo9QZF6hnO6JJKtS98F0vuF03XklwGIzftRTUgURbHmfweVAIEAUDPBXRB+BKh/FIi2A5Hrsbf6Grz5+w8xOqOtVExMnz69s9SIwjP2ILophNDwKEqGAZMwKaNtU9KD9jkryseAvm1EnamZAISK3MAcKnJ/DwSwflivzDVQYVM4qANln2tGofYv5zU5++Vskj6op6xpGjdOZjVnv9KsP1M90gxGSiopRrqd1PSBQs+96XxwfL8p0gx3znKKVPqUGlX4lcUtXZ/KhGVlZThzP/B9x3G/nutWdQXmaLv7e/U1+NyeGIr6J5cX9+/fn7RMn7HS0q4ks/79+yddbnoOpfejNDPYxjiDc539kjVNpkj9+vXzyhUVFUnXp9ecc5458nGy82l6Z1L5mo4WoF0stG56X1DDG7qcM1KCwpn2lWIzMiTdsrZ+OSvKx4DeMtUJAAAXKElEQVTKVgdT1jcBkVWupD3veqD1j0DkeiD8CAbMeQSf2d6WuiJFUXqEnP1yVhRFxt7FjwFPPIHPf/ubGDvsdGz6+dt4+8ILEPygCS8v/CF+PL4Z4XA4081U8oz7778fhdFmzLjoqyjYuwWlH65D40lfRfz0C7Bs2TLE43HMnTs3083MOnI2OEulPZM/qknC4Ui6HAmNI5tLp0X0I+s6HZKi1GfZtK2pnablUqnORso0kQ7PaKksS2U8Kn0OHToUgCsdXnnllbj88ssBAGfEYsBWoGriNPygsAKxWAx9+vTxtqMyJZ2mcPPmzV6ZZndTKdtkSEJ9nikcWdW0Pge/uiP86o4yYdqWk9lsMyUpZ1rHVLL2wYMHvfLu3bu76vjXWtz37J8x4KUfonokEADQ769PI3zXICz963ZMmjSp2/SYVM6XXhPTiA6pgQnn2qZDyqbkbHBWFEXGjTfeiO3btyf927XXXtvDrVHynaIDO9Drw3VYVvQXDBwJhDe4y2tGAvUbgPoN2zF9/DcwIck0mIoGZ0VRjoBHHnkajY3FuOSSi7BxYx+8uXYQzjyrEV/44l48/vjjqKiowNSpUzPdTCVDVL7xCxzz6/kIOO7Xa81Id3l4A1D/LhCNA5GRwE2jKrAtg+3MZnI2OEvlDul0hjamFdJpxWyMLZLBMQPxy+OWs9y0XxsDEGmmqRS/pHLTPWjTNo4MTrNfhw0b5pWpUUWiPVRqpvdOY2OjV961a5dX/tHTvfDLn5+AOGrx4u+HIYgaAAH8/ncO+vafjd17H8XEiROxb98+AECvXl1DtKgkS7P7pXKh9FnlTKMqlaBNBjl+dVnY+F1zzFU4+0oFvV8S0nTh/u04lgTmBDUjuwJzKAhUjwQ+7DO4W/fJoW2RGpJQOPeR6ZnMBp/tnA3OiqL0PLt2FePJx7+EIM4CEEAcYQABBFGDOOqxe+8ifOXL1+C6667LdFOVDFG0e+NHAjMA1G3oCszRuCttX31eevttcxkNzoqisNm6pQyO434xBDs9nuMII456AFEEEUGvsvEADmSukUpGaa88Fk4g2C1A121wJe3ISPcLOvH7rlc24uovZLCxWUzOBmeOfC2VbqWSj1+SJUeCoqRqs2nwPccLnNN2jgcxxS/zDb+kbJssbhNSmZViI62ZltN6unk0E4OHhJxITUVoli31qU+UGxvjABy4ObfwvpiBKIAQgqhGea/1LD9yGzlS2t1hqt+vkQQ2RjgcpOdKKq1zfOsTZbod7ZrwphgdOBwffGOO1+cc2QDUksAMuJJ265CTMP/JnwIDhnYbSsV5BkxIr5W027Enp4zM2eCsKEr6ePjhhwEA11xzjbes94Yy7PjFEMRRDwcxFOAOxFGHRGAGoq60vftyAGpo8nFm9+iL0HDCF1CydzMOLq7DvJFbUDPS/bfu4FEj8c+zp+OKUWfh4AMPdOu3VrrQ4KwoykcIBoN46KGHULSzADOHT8Hxf6nCwNf6YCHuQxx3IogI4qhDHGEEEen8gnZ/37tvG4BrUu5DyW/aex+F9t5H4fz5j6Fi+9vYsO1vaDr6NDQOPhkAUAp3eJ+SnJwNzhwpyySJSD1XpX7QHEzSGid7NJWkJ/V8lcq86TAY4VwTU3s42agmbGRtv2RQqYxrQjr9XWJKSJqVfeCA21c8btw4VPy+GEt+sQyD0BfVmIF63INfYSGCmAcA3QIzkOiDdrD+b7VYvbrAe/FS6dNGtud0ZUmzlG2mDLTZ1tQ2m6x1zjrJZOpDkTwH9LmlIwTodKPFxcXAwIGIjjoLZUVFSHSy0Cx+k/+6zTWRzpVgmuaSLqf3MjVL8av7gpKzwVlRlPRR8XYp7nqvGr1RhjAWoh73IIooIrgdQzEd12NJZ2CuRlcftIPp0y/Grj3vWblVKYqiwVlRlCT0WV+GAAKowS1eYA4hhBrcAqAN52Iq3kMBjgvsxZoFa7GxNYQRIwKorGoDcIVnGaoouciiRYtQUFCAmTNn4qnQL/GbkhcwtvVsXBn/FhYvXoxYLIba2tq0tiEvgrPU75oiHfTP+SKwMbDgGJiYsiyPtD4TUkncryxYG09pTmaltH7pcZmQSpAUG4kz1SgEev4SJiFNo6Nw4HQLzFFEUYe7UYNbMAxxDA3G8MGcPTjl7H44Bd1lTTrFoZfFyzwOTtspUqmc8zxLTYhM+zLVI53a0gRdn0rJnFEl0mNMbGvajl5/Kv/27t3bK9N7jd4XnGeVk11OkXZlHFrPggULsDL0OBpqHSAAPBd6CbWRO7B/wWbcdtttRrnbL/IiOCuK4i+NJ7fitk/UY/E/lyGC21GNGajD3QhjIRw4uHr8d7Hl4r0oOq44dWWKkmN8e+blWFP0Z7w672WgoAKo6Q3UH8D+Ow5i7JyLcMu0W9LehrwIzpz/uijSBCybZBLOV6ypPaY2p0p6oPuUjvvljBP3a6wq5z96m5lfbL6KONv69dXl19c+Z1+0/sRXMv3iSdyjDz74IFb8cwWmXjIZ1x53Hd4+dTu+Wfkd7HmwCbW/XISdlY2YeNLEbnagdDy1yaZT+sxwrFBNcO4pG1taznPLeV/4dY/7ZUVqugdTvUvoPun1p1/IJqQKls3Y9lTvtdVFP8G0ijsQr48DxRVA+CBQf9AdMRipgHNrLwQOBljvQRvyIjgriuIv8XgckyZNwrUTr8ceNHsmJN+tvQaxox0dm6rkJVsC2zGt9A7EA53/rNT07grMIQDVvTGsaXCPtEWDs6IoH+Gmm24yfg1MnDixh1ujKD3De8EPugIzANQdoB47QP0BxGb2zD+mORucbez7pLMkceTxVElagDlJgzPjjESetrEb5CSSmOo0wZEmpVKtaTlHnuMkEHLg3Gs2sr8JaaKj6dwmpEeasEMlSLou/VKm9zed0YpKmZxx6xTO9ed07ZieK45FqtTGlsr10qQkE+mw++Tcg5LnQGpVm27/ABPS5E3HcXB8bDiCTtAN0HUHXEk70tnn3Pn7wbbtKJxZmHYrz54zClUURVGULGaoMwj3ttQiEDnoBuZ5FUB15z+v1b0xtHYEnrnzKSxevDjtbcnZL2dFURRF8Zsroxfjraa1aJhzELMn3471Df/AC8Wv4Oy2L2PstLOxuH1xj+RcBJx0pJn1AE1NTUmXS2cZ4Yx/pOMHTeNrTePcpBmd6chaTrYfGytJaVYrB7/GlZq2lUqW0uOSZiFLx5ty2mki1XmgLxppRrRJIrYZ2+5XxrpfGdE22GR627iscbropPddsnHOnO4C6T0qvW7SrHwTdB06Ixs9LnqtTPcptSK1QWVtRVEURckyNDgriqIoSpaRs33ONjIoR3KjUh+VtU31mCQoaTYwJ5OcYsqiTdYuTvaqjTEERSqf+ZXRLUUqd/tlGCGV39Ih3Sa2NV1/aca1jaGHzbk31W8zCsKmq4Rj5GPzzHHWsbGZpSQ7V36dPwpnZjGpiYvUQpiWpTNOpaN3WL+cFUVRFCXL0OCsKIqiKFlGzsraJkz+1X5lLHImKLcx5jDBMVpI1CnN1LTJCpXKThzJ2kZyN2GqhzOjkV+kQ8qUSuK0DYln5UjNKA7XLs5zSLGRYTmSsk0msdTAxKYLyNRmjod2smt7KJx3oolU7wlpN4U0i9s0qoDzTpYaVZnqoZi6EfxCv5wVRVEUJcvQ4KwoiqIoWUbOyto2Eqd0HeoZTKHGI+nIWvbDzIIjKdpImRROpq/UZEWacWnjcW1jliDN6JRKbtL7gtOdkShLjTI4xyr1HebIrZzzJL1HOOdMmkluk0EvlWgpJmlVet5SvSdsDH2kPugc+dpmVI5fvt/p6BLTL2dFURRFyTI0OCuKoihKlpGzsjZHBqFwspNNvtm0LM3KtPEb5mShJqvfL8OKdJhjSCUxjpQl3ZdUjj5Sc48jqccma1kq1yXWkYwEOFx9yeo+XFukUrCNbzLFRpaXPkM2I0M40rpfnvGc9VOZ1lA4o12k3WzS96e0W9DUBhPSrG8p+uWsKIqiKFmGBmdFURRFyTJyVtbmZCxyjCekWbBU4pbKdRQ6oJ5mfUtlomT7spF2pXIhR/6TekpLs8dtss1tTCJMSLLpD7ctZznnOaDrJDNy4MhzfmXK23SVUDhyrlRCl7aHY7RiYypDMR2v9N6XdiUkq99m5INNd1Q6Rm6YRpj4de/YoF/OiqIoipJlaHBWFEVRlCwjZ2VtitR8gWNyIJXEpSYBfmXCJpN6pO01IV1fajBgMrmw8SmWSk1+ybJ+mZxw2snBj0xS6fFJ6/HLuIdzv0i7TTjLpdO72rTZdD2lU6qa1jdNPZusHr9Gfdi012ZfpvX9mkbXL/TLWVEURVGyDA3OiqIoipJl5KysLZUXTRKHaZo1TsagqT2m/XLWl/oZp5J6OJnS0mOyybKWmilwpD2bDHcb8wBpPVJ517St3xmsUimQrtPR0ZG0LRQ6GkF6bU1w1uFMoSi9DhTplKcUzjnndAdRODI+59lN9T6wMcexkcQpfk1Va7pHOPI7vffVhERRFEVRPgZocFYURVGULCPgpCPNrAdoampKutyUdWjCL79eikk2sckkNi2nx5g4dul0faa6pVnfUvONdGSPS+VuqSTuV6aqdB3O+lJTh1TbmWhvb/fK0Wg0aZnup7i42CvT6Velz6fUeMRUD2d9G2xGj/hlFORXJrxkJAnn3SHFplsrHXD2W1ZW5su+9MtZURRFUbKMnE0IUxQl+3g+9AJeKHkRn2kfjWHOMBzXcRyOw7GZbpai5Bw5K2s3Nzd75WR+wYcr+5UxSOGcRioHhkIhr8zx6D1S/2ibQfYUm6zWdNTDQZr5zqmH000hNcIwwVnf5vFNZlrDaQuVr5ubm3H33XcjGAzixbo/Ym3xm0AAgAMgAAQicYxpOQePT18NoLusTZ8BTra2jZRpY0JiY8BDkcqyfhnkmNppupdTGZvYZGtzzg2nnnTUyYGzX5W1FUXJCoLBIJYsWYK1d/2vG5gB92ddDE5tDM+XvoCtwa2ZbKKi5BwanBVFsWL69On4dPVooDYO1HWqQHUxIBwHIkE44QDeL9iY0TYqSq6Rs33OVFKQZn3a+NdSONIkrYfKeBx5iXKk8qXUe1eaoe2X57NN/aZtTVK21PzCRsr2Kwvdr96nZOfBRp5PMH3qdFxddLUbkOvjQBRAJAjUFAAO8NfYqxh18NRu25aWlnrliooKr0zPt7Q7gpPRzfGRlmZN2xjS2Ex/aeMZbao/1XvNr3vdZqpXU51+SfsmejLrX7+cFUXxh5oCIAQ3MIc6fweAALB4wD3YVrA9g41TlNxCg7OiKNa8UPIiUB/rCsxRdEncAKoCMewtfxZOwbZMNVFRcoqclbU52Hi6Sk00pJm10ikjJdKUX9mofsl8HA9iv6RyiqkeqVe6TWZtus0SbI492ToccwxaTmRfNy9oBObHu6TsRJ/zi3Gc8vUAnql2UFB1J2KVCxDdNBcde/4Ty5cvRywWw+TJk7v5b/fq1euIj48j89pMGZmOzG2pSUe6u5KO9LmUnjObZ89m9ALnGlLfbHpv2twXUvTLWVEUK+6++278ZP6PMSQ8DKjulLKrC9xAvQZ4K+zgoXp3cSAQR2j4nfj+qqVYtmwZK19EUT6O5PWXs6Io6ScWi+G2227D1Bum4vm9L+DF4j9gSMtQNN18EO+3voQd/7MWy8LuujfVAA/Ux/HAiicwZdoE3HTDTZltvKJkKXlhQkLxKwNY6tHNkRE563Pql2Q5SuVr6XR3Nvv1C6m5h40ZCz0Wk3mMzfHaTN9pWp6qG4Jzzek6tA56Dmh5//797roF29A+/Ew8UO9gWRgoCgHtUWBKBLixOgBn2zw4+y9G3759vW1p5jY1LaH4ZZzDkXOlIz1s8EuWlT73nHdl4t7wy7jDr8xnv8xpbEaS0HJ5ebmoDSZU1lYUJe3cVNMVmItC7u+BgIPA4DuAQs3iVpRD0eCsKEracIo2IhBwsLKuKzC3R4GVde7fA4E4ENqU2UYqShaSs33OnKw56aByk6RIMWXxmerkSMZ++cRKtjNJwVLzAhtTDhtZ0CaL1+a+kJrfmNrGMTyRSrdHCqcrQHq/Jp4Nx/kElkUCWF7rYErE/WJeWYeuPujqIIqcE7o9S3RfJt98znmyycq2Ma2xGRlCsTFOMmGT5Z6qXSak69tkcdvI1NJ3k/TcS8nZ4KwoSvaz7J4fYfk9DibPC+CmGgeO4wZooDNAN34dk68fnNE2Kko2osFZUZS0EY/HMXnyZNx02bfgbNqEeEcxULQFE68GAvveQrzFnxl8FCXfyNls7ZaWlqTLTVmlUn9kk7RiI3dwzDikhgTJ9ssxETC1ncr2VLbltJcjmZmuidS4Qbovm3VM2MjyNl0ZPZVVbPNqaGpq8sqtra1emcrU1GueZrjS5Zy22zw/NgYz0tEgnOtjY5Bj89xL5HebZ14Kp4uQ479ukxnOiQv0nFDPeBs0IUxRFEVRsgwNzoqiKIqSZeRsnzNHjpBON0fhyDJSedEmu9OUtZpMcrGR2EwZ6JxtTetwtk2337GpnnRkuNogvUdM8iinzlT12SwvKSnxyiZvYrqcM/LBhFTKlsrgnC4daZ2ce196XNL9Sp/jZPVLR7tIMbXL9G7ndH3QMsc3+0gNoGzRL2dFURRFyTI0OCuKoihKlpGzsrY0e9jkg2ySRGjWMsWUJWiTkczxM7bJSEzVRpvMZFNbTN7kPelHLPUU5mwrbbPpGnLWl8qORyoxSrOUOd05HMnahF+ey6ZtbTK6OeYx0qxsDn6ZkNiY9yRbx8aLXyojc+AY0tgYHvXk4Cb9clYURVGULEODs6IoiqJkGTkra0szeqm0xpFc6XJTpjRdTvHLN1tq0pHYlzTj12Q8IjWyMPlOSzO3ORI65xxL22wyOZCaPnDqN+GHSQR3/WT3i9T/W7p/kwxq0+VCsekq8StTXdpVIjUnspH9OZKx5LmXjrKQSu/ScyzFdI45o2Mo6ZC79ctZURRFUbIMDc6KoiiKkmXkrKxNkcoOJilGKpWbpCbp9IompHJQYr82ErQ005yTjSqVpjimDOmWIE3X0NQFYMIklXEkRRtJ/Ei7UziyKmf/FKkXO0VqAMR5hm1GD9hI7jbdRKZ6THAMUkz3o2S/0mxxqV84hfP8mPbFmSeAc4/0pCGJfjkriqIoSpahwVlRFEVRsoyclbWlEpppW47UZPJfNckgFFMGsFTWlJhKcGQ+G19wk1zEaaPUI1oqTUvNFKRSptS/mMKR6zmyn/T8pLrWpu2k96hpHRvPZ6n5idScSNoev7DJAOacE6npEodEPSYpWPpO5kzLS5F2R3COW2ru5Jc5EQf9clYURVGULEODs6IoiqJkGTkra0ulQ9O2NjKrSaIxSb2mTElTJiHNDKbSeipZSWJYciiSrPDDLefI6ZxsZ1PbOD7l0uxYm3PCWV/qJezX1Iap2p/uLOWe3K/UCIMjp3OkTE53hGm5TdY6536RPiscYx5JG03rSM+rjVmLzTk2raPZ2oqiKIryMUODs6IoiqJkGQEnHd/jiqIoiqIcMfrlrCiKoihZhgZnRVEURckyNDgriqIoSpahwVlRFEVRsgwNzoqiKIqSZWhwVhRFUZQsQ4OzoiiKomQZGpwVRVEUJcvQ4KwoiqIoWYYGZ0VRFEXJMjQ4K4qiKEqWocFZURRFUbIMDc6KoiiKkmVocFYURVGULEODs6IoiqJkGRqcFUVRFCXL0OCsKIqiKFmGBmdFURRFyTI0OCuKoihKlqHBWVEURVGyDA3OiqIoipJlaHBWFEVRlCxDg7OiKIqiZBkanBVFURQly9DgrCiKoihZhgZnRVEURckyNDgriqIoSpahwVlRFEVRsgwNzoqiKIqSZWhwVhRFUZQsQ4OzoiiKomQZGpwVRVEUJcvQ4KwoiqIoWcb/B4MKcWpmT8R1AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "peaks_refined.plot_diffraction_vectors(\n",
+    "    method='DBSCAN',\n",
+    "    xlim=reciprocal_radius, \n",
+    "    ylim=reciprocal_radius,\n",
+    "    unique_vectors=unique_peaks, \n",
+    "    distance_threshold=distance_threshold,\n",
+    "    min_samples=min_samples, \n",
+    "    image_to_plot_on=s_rb.max(), \n",
+    "    image_cmap='gray_r',\n",
+    "    plot_label_colors=True, \n",
+    "    distance_threshold_all=scale*0.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Filter the unique vectors by magnitude in order to exclude the direct beam from the following analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "53  unique vectors.\n"
+     ]
+    }
+   ],
+   "source": [
+    "gmags = unique_peaks.get_magnitudes()\n",
+    "gmags.data[gmags.data<10*scale] = 0\n",
+    "Gs = unique_peaks.data[np.where(gmags)]\n",
+    "Gs = pxm.DiffractionVectors(Gs)\n",
+    "print(np.shape(Gs)[0], ' unique vectors.')\n",
+    "Gs.axes_manager.set_signal_dimension(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the unique vectors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAecAAAHVCAYAAADLvzPyAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsvWewHFl23/nPzDJZz8E8eKDh2gFt0N3TZqYHtkkN3WgpihSDIc2K2lh92AhqqS8TFI1G4nBnhgwyQlSIUlBLxpIby12tzJKUZmg0o9EMTHeju6ct0A7d6Ib37gHPVZbJzP1Q7+U9F8iDOhdVz9R75/cFF1k3b97Kysz78n/P/R8vTdMUiqIoiqLMG/y57oCiKIqiKDY6OCuKoijKPEMHZ0VRFEWZZ+jgrCiKoijzDB2cFUVRFGWeoYOzoiiKoswzdHBWFEVRlHmGDs6KoiiKMs/QwVlRFEVR5hk6OCuKoijKPEMHZ0VRFEWZZ+jgrCiKoijzjMJcd+BeKRXXtK3jeeZvD4/8HZIi6Uof0tS0IzmWpA8e8/cSrc8d16VfSdrMPQ7F98zlQevT7bRfbJ20/fmm7XSyL6zvnt9P63sldbMvPZeC41pI9u2kfclxKbR9pk469Xt167rk6kvuN65+4IdZuRj0m3LBlBvNCVOOTZleO4XAtFPwfIxFJzEYbsHaynPZ9snJUzhXew0A8HC4Bw9VdgEAxpIaTkWv4FTtMJaHj2K48ggA4Frjk2zfav1aVm7Gk22/L/u7USTXEVPfuvbpvS64Bq1nVk479Lfi7jEJ7DUiuIcl17fkWK7XvuQ7NhpX2taR0LODs6Ioyr0wGG4GAIxFJ1FCP4Yrj+J69X1cr72HDeXPAgA+ig4BAB6q7MoG5s3lz6NYWT9X3VYWGT07OKfcm5/1l6EpJsivL/mriHuDdH3LZd8OBX+NcW+Qedu549NjcvX545vvzdYmx3I+33TflHmbZY5F8f0SaYf0gWmf+yva7jTztuH6Juz4tiz5C99L8+tzx/WYa6DdcSSw50+AdV+R80qVjSbTfpI2srJ1v5E2m3GUlaN4FMXiclSSGq5H7+F69AGABOvCZ7EmfAoAMOSH+KB6EMejl5EgxkPhbjwY7sJJnM09bjMx7dv3ubkeKbRvrm9s1psrreORfT26r9v16zH1s2uHeaZJrm+rPvN2b30n5jnPvmkz54zmRebOGaskcHW89v3sBJ1zVhRlUVIpr0XrEZgA8LEufDr7bHvfbvgIkCCGjwAPhrvmqpvKIkUHZ0VRFiXV2kVMD8xAggvRm9lnH06+mA3MCWIcj16aq24qixQvTdO0fbX5R7Gwwql+twKzRAEQjDwiCVDijhtTqbcbuAaPMHDBWyK5yzEohpWgGXmuXWDL7e1I6lNmOvDP2s6cQxowZU09MDJxu75Ijt+uvdvbdOnL3Y7LTi9Z8mJ+P+n2wA8RJ+NIkgmUCsMoFYdRb1xHvXkdA+XNAIDx2iksC7dhWWUbrlaPYiw6gcFwK/ygL2tnonaZtE/7Q6YOJNcv/b6OwXMSuOvaeYpmqo7ku4pgrgVO1u7W9+Cmdrr1zNKAMEVRlHtgemD2/X6UisMAgFJxGKVgEOO1UwCQDcwAMBRuBQCMRSdQLq5CWFo1J/1WFhc6OCuKsrhIAd/vR+APWJsHwk2oNUcAIBuYp5keoOvx2Oz0UVn0LDxZ21E2YyMDJRG6kjYFsqYla3v5ciArGee0yclOXVvf1621xBSJJOYYHV0gEiQ9fzGJrBW130G0Nhe5y/4WgmuwWxJ6rkzJRkS3X+cukb5dpwu4+p14FUii8gPyW1lTSp1E63eyFt7xuWbhKK1b3cmRgLlrVHIdsZIy0yY3ldE1nwCCZKUHC+lzt2RtDQhTFEVRlHmGDs6KoiiKMs9YcHPOrLQikAjthhxlTbqrQAKmcFI2Z7HZVsr02kudnIwkkbLZdgiWCYlEpqJ0IP8VCwM5lQHfK2ZlKlN2dL1w0aCcSQRnuoL2ciDXvmS7SELPbVDwPQgSYx1JpLx9nu4tAv329kXyK536SM3UhyWtM4YUEnnfk0wgCq61dkYyt9fnkKw8yb1GBOYlnnWf02kBJtLbOih9xuZXoRI0naaS3D/8qgzm3u5kKq4D9M1ZURRFUeYZOjgriqIoyjxjYcjakoXnnCzHSXec/Eb9ayVGApycRuQU6ssrMQdh28+RpkSRwFzfBVKayLSE882m/XTMosNJjQ2SESiwoqOZiNsOcJWRKWxkKIOrOQUXXZ0nDbtOZXQLkac7GIlYYABDoSsGJPI7K7kz9zCVrEWR6sx5Zj20JdmZCJLIY1GWp3vMpCYxDGF/f2aaj0J/T9q+ZJUIe9/Se0YSuc1M13ULfXNWFEVRlHmGDs6KoiiKMs/oWROSQmF5VqbmDlQ2lfgmszDyhUjKlsjBHSQOZ5luRxJd2IHhhqsvsChCW4BTpHGndJCU3mqG9DkgUhmNHqc04gnTfpfk7nY4p8rk2unAMMQ50tzRp9r1mhU9O1wjertkQsJK65L7oxvGKY7PDleJ2NnXupPIasfjsr7iBDUhURRFUZQFig7OiqIoijLPWBDR2iJPV8ZswPlYrhGOEhxTp7WTlUTylkQK4iK6JZIZgfXWdpSvRFK2IPpeJH1JZFzBNeX55hYrFQazcrkwlJWbSc00gzgr08jzTvyROVkuD1cZeSZSa3aU1pBDYJxBYc8xd1xBqlJRnyVTSR1EP7PbBX75TnWZiGufNSdx7DsDO4XWJbnbNV1nJyyIwVlReoGofgWe56FcXHnHZ9X6JSBN4fnlOeiZoijzDZW1FWWW8DwPtcZV1BpXre3V+iVE9YuAx3gVKoqy6OjZN2eJD7JVXyC/2Tu4mV9wdBJNy8lEFjn9tPolkYU68BFn2xEg8faVSGgij+YO+inxZWZlX1LuK2+A5xUQ1S8iCgYxFG7FaHQCUf0i+sv3ob98H8Zrl/K73EnkscN6DE7ClfhUS/rIRRdDYn4i+N1c5WjJ7yZqn9DJFJrVPvndOE9vkdQvkMrp9IvLigrR860T6d1x+s011SNNK9uk00hc32bYmIfSs4OzovQildIaAMBYdAJj0UkAaTYwK4qiTKOytqLMMq0B2gOQAvB0YFYU5Q56983ZMYqPkztZeZw5lsRsRBTR3a0F+PdKB9HaVhXX70274Ojj7JTW7vbjdsN8Afz0CBeVS9NT1hq3AACN5gimB2YgxcjkMZSmTHWoCUknUcX3PJ3C+AVzvt0SuZW2wxmx0HR99jnovtlMJ9HUErne2SCHi8p2lOJFh+KmgJL8azl3lYMktSJnoMKla3R8doiudYFUbknZkufzLKaP7N3BWVF6kEZzBI14BOXiKoSlVYjqV1CbchQqEdc7RVEWNzo4K8osMT0wF4NlCEurAABhaRWStIlG88ZUrXxbT0VRFhc9OzizkmKXDECc++MqrdAqgpSUIhONdikAJQgiOzuJrHaOpu/Es7hLafC4CFqJRzv9LnESwfcqSOFjIrpIannwvQqacRWB334JgGvEcNtpHHIOCn5oykElK3PmDgmRQ+vxWO5xCr5pp1gw0bGeF5g+psZ8hcJ5jbt+bxaBdCyiAynbeZUDJ30LnjXsNAi57NrefwKDjo5WsnTg429X6o403VEfOqBnB2dF6TUCv4/9zL/LZ3NJrXENHjyEpdV3fFZvXEeSxirHK8oMoNHaiqKwePBQb16/wzil3riOevM6PKhxiqLMBD375kzTRHLRkVaqsoRJJWn5vpI2JZHEjtHXnIEJKzWRvgVEbozbpMWUyC1cGjc27Z/kGcx5OAskJW6awjXynU1PZx3MURLn6FI0rRU1S7+LxKRFcFxO6vWnbn87gtbULQb9KAb98OslRPWLKPgVDIQbcav6CerN6whLa+B5ZcsPfBoalV0qGk/x/oKxLi14xqq0loybPlqmFabtmNzDcRLlfj+K67lnDVJcUwlK3nlco3slzxeBp759HbVfpZH3XThzJFep2XVaqKPIbeb8BeSZH6OOPEQrdGbgb9SeHZwVRZkdKqU1CLwiJmpnMFE7CyBFWFqDsLQatcbNue6eoixIVNZWFKUtA+FGUOOUvDloCaPVTzEancj9bDw6jbHo1L12UVEWFD375kzTjXFSLCt9uUYhd7LwnNk34CR0uiuVXMj3ZdOiTbfHSMSWkQSTxpGTrNjIzg6i1FlZuAPjiYSRF0WpM+nmDtIySiRIPoK6fR+6JXFbKfumoNIxjZSO6pcxPTADKaq1CygXV1r16Tmmv0ORRGuXPB9XordRwRJsKO/Mtn9SO4Dx2ikMh48h8c1ysmnjltvbFJnBMEjMY5xTZzq+5/D3fP796pqmVSK5c9N+bD+nz4/rCpdOzJo4L3Dr++VPBdF7iZviEj0vmP5otLaiKHPKdPBXpbQOlfJaTERnSICY2yNkdfgEAOBK9DZKaQnrw2dxPnod12vvYTh8DMOVR3G18XGXv4Gi9B46OCuKwnL7wAwgy0dda1xF4A8gCAbv1sQdTA/Q56LXcL72OlIk2cCsKEqLnh2cOTnK2ePW1ePa6kR7eYeaOlD5JfDLedUtuSZJG2bfOD+i19p3WpYRSHWu5h7OshpHt1J6Cn5zkewkiKx3jdbvROLkPKw95jyz8qjEhCQHKm9GjRHEcRW+34c4TTEeXQBgpos8L2z1kUwfZcck56Mem0jsKGhJ5UsqD+BqdAQpEnjwMVjZgjpaPsf0updE3NNVFpYfODlnsSXbtr/PRb9/l/yUWZMLiRkPU982Zsp/zCdM+9a0GTP95VJXlOqViXbmzg07LdeBP3pHxiYz4K2tAWGKorAEQT98vz/3M9+vwCfzyS5cr36QDcwpEtysqpStKJSefXNWFKU3uV79ADei97Em/AxWh0/icvQOLkVvAQCWVh6a494pyvzAS9M0bV9t/lEsrMj/wFFqcI0e5CKlOanETpdnpGzfN9slHsb1hvEttvyG7zFi0FX2ZCU2ibevawo4RznPOapVIFOz0dGdGFIwdezpDjINYpmT5Ndnr0eH6YbUkvPdDD0k1x/9Th5i1BpXUC6uwlBla7Z9tHoi257CeG5T+VIi4ZcKS7IyvcfqTXP/cG1KIuJdpyxEzPA1zj7juPbbGXlw9wlz33bLm7orKVGluE6Vku/bmMoy1yn65qwoyiySZukyKeb/PfmuoChdRwdnRVFmjbuZl0wP0NX69dnqjqLMWxbe4CyINhZJRAyWR7cgCpGDeg/3kaw+oWdkuWZay8q30rNZmcrabaUe7nwwspCrl3UnsGYqjgYmnD8yGwUNRnbmItsFOK8MIHjc7+JYn/PibieDu0jgd/SRbmeOQ82AaKrMCdcpKOZap+VmUs3KAdqbbLDHkkRrdwtH0xrnlKeuKy3aGYLQftEUt13yyub60i3/alfjKYlc34lxEsfCG5x7kNHqSXieh8Fw8x2f3Yo+QZqm8ArhnTsqiqIoCxJdSjUP8DwPY9HJO3yFb0Wf4FZ0HJ6nafkURVEWE7375uwoL1DJxZL/qGwi8Ojl0uulSb70QetTcwXPMxGpqypPoYAQI9GHGMQKrAufxoXoTdyKjmNl+CRWVXbgYvP93P7npY/sxGzEgovclZwbzmAgpefDTWrk+iAxHuG9rNtLhJ1E7soi4Wn7zPUrkOK4aO12MjgngbNyO4OkPu2jTx4/nrWqoYQ8mvGkqc+cD9p+3GyfVpJFMMXRNenbdVrBNT2l6zXerj+OhjjOSJ5NnTTvKPNzU2XOEr0jvTs4LzCWV7YDAC5Er+Ni9CZSJNnArCiKoiwuVNaeRyyvbM8ckzz4OjAriqIsUnr3zVkSxcfII6xfL9eMIN0YGBnRbodKInFWjtJRAMBodMKyNDxXfRVLKw8CsE0U+GjZ6ejb9rJzR8YHAs9tTsp2NUrg+iCJjuzEtMA5ZSTXB4GBgSRampOsrQhpJgUgHxV/b30R+RcLDF2oOUm5aFYplIJ8u9BabO4BLpUkez0Kfk92WoD7/V399zvw6BalsGSWiDvfBy4SvcRUSDIlwkyDuRrDuKahtOpw3voMkpSbndC7g/MCYzQ6gbHoBFaGO7CysgNXq0dxNToKANkArSiKoiwOdHCeB0wPzIPhVqyckrJXVnagjgi3oqmEABqwrSiKsmhY2N7aBIkntiT6TuJJ7TESOq1DI1LjeBzwPJQKyy0/4Diuo9EcQYrUyv7TLsJcIgvPuA+2o6+51QWBNNWJ97VrZK0d4Wx+N/ob+l4xK8eJMY+h0fQSKZ6NlpYYkjASN+fLndcG1xcJknbofdhXNm5hS0ubsvKAN5yVGyBGPPH5rDxWM+UGieJmzWkcI+spEm/oTurYB+vA7MfRP17kH53zm9Lvwa0ccaaT5w6Hq9d4B577dHu9cal93wTom/M8oFQcZj8rFpYBsJ2PFEVRlIWNRmsrijIvuFk9jlvRJ7mfXa9+gPHozCz3SFHmjp59c2b9lLnIamtnJtJbslhfEIVsSZOMDNIkfsOx5dctiPRmoq6z7RJPXgkCn3IRnF8wYx4i8ujtQMp2lS+5qOKwsDQr217SRoqlEcZRfYTUIQYZnGEIIwdLTEO46FGJVJ7bL0GEM9cX2nf6m9BUqavTLYhxHeejH2AN1uKhyi4AwERSx8noFdyovY+l4cPoC1oq06R/LduXytqSyGDn6OEZkLvthvLvLdYsxzqYmzc0jeh2nVbKmzbrRMpm06l2Mi3HHsxtGsyeFurONeVKzw7OiqIsLNaFzwAAPooOAQAequzCyegVnKy9jC3lnUgry++2u6IsKHRwVhRl3rAufAYDXoiPokM4Hr2MBDG2lHdiS/g8TuCjue6eoswaPTs4c3KRs98tU4dKmVSC5I7l7NcqkAkDEhkskU2m68cp6a9rxKJrtChXn5NErUj2/PSbFNZkgTMVsHbmpHI3M4gCiZSvkPSeK4KtWbkvHcjK1YKRWW8GF8xRif961MiXA+3riIn6t75vkltfIoPnbeNkb1dvbYp9TYe522PPmPI8VNmVDcweAmwJn7+jvoS5MqFxlruZaTB753uPZpb0h2vHpS+SSGZRqlpuewcraCSpISnsih7X9jtAA8IURZlXfFx9CQli+AiQIsbJ6JW57pKizDo9++asKHPNleoRePAy4xj7s6MAEpTCVbPfsR7mYvQmLkZv4OFwDx6q7MJ7kwdxsvZy68PK0Nx2TlFmkZ4dnDuRlPlGTX1OyqbQ47I+q44p2qhUwkZCMnJtVp+JlGXTnVGsyGFG+hb0xU4H6SjDkXZEEasM9vdlJHSBdE+NYSrBsqxcSH18WnsJQ+kQdgz9ULb9yPhBXI3ewfbKXpSwMds+5huJm5UOmXSmFHt7exmaXgMe+S7T2zlvaok/tm2I0z5am25vNCey8uXCp5lT3orwcXiV9TiOk/D6VmKZtw0no5dRSlagXGyZD1GveddUnxRPMHXQUbQ2c63NREQ3O00kOa6LbM6cG9FzmFspwxrotJ9aYaPL/fb3ksT339Xru1v07OCsKHPN1vDzAIBPay+hMlHAY/178N7EIXxYPYjtlb3YXtmNT5MLbVpRMtIUg+FWrKg8Zm1eVtkGAJhoXp2LXinKnKCDs6J0wPQA/d7kAXww+SISxNnArLgxVLmf/WxZZRuaNfZjRVlw9OzgzBpYOEo13fJftaRsps1C0JeVqfEI912sbtL+EJkltz45ZgJHUwMJkghNLvpaIl8LPH9F0d2O8Y7cvs3YWKdSeazoBQCAhyu7cbL2ShbEtLX8edSSVvTxpGfk10ZsZNx2EdTA7ZHT7b879/tWSsYelkabT/uBNxMTXT5Zv56V602TltH6zS0jC+aaYmTKIkkHWSmSKQKvnJUjjGflamKMWyjWdI3HTF84RglL0mWy+4K5J7g0oZ2kIZWsVJHs6+oxP/1dJB73dD+J/MutEnCdspSY7HQpdafrvq5otLaidMjxyEQXJ4hxPHpprrukKEqP07NvzooyHzgevYTj0Yt4on8fdgzswdHxQzgycQAA8GC4a247pyhKz7IwUkYKjDBYJMYZtLpj1LLrvh3Jze3ac02/6NomQTItwErQrsYmtJuCKQhXIwH6XahEXEg8jEQfYlm4HRunjDIA4FT0Em5FH2NJ+BAaRJarNY1E65oC0qa98UilvDIrD5cfzMqrE5OasYKWlHzTG822XYFJPDFWv2j63jAStySClvaFStmD5fVZ+T48mpXXkyh4nyQvv0KmAs76H2flm/XTWdnyLE/zV0rwJi4g29uvAJFM44imXxw9tDtK/Wo11F5+b7dKQ5S6caafO5I6rttdYc5xo3ktd7sr+uasKPdMimXhdiyvbAfIn7hLKw9mnyuKotwLC2Nwdp2MF/zlxP51KlpTyay7c7TMFAWl5SVDZ/ZzSah+Z6NufWTb595+mSAQSeCMxJqPa1OUxYjsO1m7nJX9KbvU8bGXrTdFy5ZSsF4eTHCYx6x5ZgPCyHaaMWttsiUrP9ZvAsKGiq031EtV82ZbrpnArE8DE5hF35ytY9JAKGZtM83ktcZ7KCs/1WcMWh4YMm/L9E+aT0bNvrUJ89ZfDczbct03QXdx3D4bF4ck2xob9MTtyykkzDVYIPamHDE9FqdEcW/y5ORKvou9Xr50x+cWkqBbehxHFZJ7prAeE11SVLtmdeyIBoQpiqIoyjxDB2dFWQScjV7FuegHuZ+9O3EIR8cPzG6HFEW5K70rawskC0nQBRcIQbNSWfaG1HKOdkewvtp1jZxz4MdUHW4/V7s5Tqq1LT5J+0l7WdA1uw63L2f9J5LfHSVurg61S0w6SDpv/43MrfF0C6ShdYZQQYgSPqm9hONRBXuW7wMADJdSfOfqQRydOIDdy17AxoEA1+smu1bgl29v9s7jMAFsnm+2F0lWr9WpkdWfW2E01j1rzXRBMw6y8ncvmMDP85NG4r7gGc+A6fXawF0CthibTglsANkMZCuia87pM4gPDqT9zLfsdLUH5fadvh5Ftr4UV0mZmR7h5Hzr3pNIzRLJmlYXPLdnwsqzdwdnRVHE3B/uBAAcuLEfALBn+T585+pB/PXV/di97AXsWrZvTvr1zUsH4Hse9qzdfsdn//bE6zg+GuLHV70wBz1TlLlFB2dFWSTcH+7Ehv4iDtzYjxdvHEKMGD+x8gU8Mbhvzvrkex6+efkANn86gX90/zPZ9n974nX86xOv4SdW6sCsLE56d3CWSBYCOWc6AhGw5atCYKQ4KinVYxMZGpB9EybCUbQ+0TGq0ElWEqx35PrFJhwn2zuScztZ88ztS0N9ue/IdYfJqiTJMiTKwiXoDxehbfWTi8ol26vNG1n5UskkjHissBs+WgOzjwCbyntxZjzOPj+PS1k5at7M7Yu9ciC3i1Z96zryzXzE0mITf3/DToRBgn/1ySH09dfxSzt24Hfeeg//+sTb+JVHn8IDwR7+IDnY55h2k0YdM9M1TDtsRq4ZkDKtLHNMpD8rpwtOk6vVcd6xXKfnXLPbUeKUnAPHNeCS43LTclYEuCSD3wyEb/Xu4KwoijPvThyyrEbfGD2Ih8K5TdLxs2t3Y+vKW/itI0fwL959F/Ukwa88+hS+/OgT+OaxOe2aoswZGq2tKIuEy9E7ODpxADv69+HvrvqneHboBbw+uh/vThya667hl3bsQMn3UU8SlHwfX370ibnukqLMKQvuzVliwchF/VKZOqAJv6lJQGoiKJuxiax07Y9k0Ton17QzG3A2G3GMfLd27cDYpJMMUlYfuvQ3Jhd57DPf0Zadu2RyITjPbFYisp1aWp7Eq6g1rqLWuIqB8mZcKaT4Xu0gAr+IwXArjk4cwKfNExgIN2K8ZmTtenMMeUiikWnWNSqPny2b/NZvjpgUkX954CTqSYKiF6CexPjy4U/xpfU78fGYOdYVmO9Ui40pSpI2cvvAZf6SyNFcdLfEXtU1u5WFo5mF67Vvm8YIIpXb3dMSQyfHVRB2Jcdnk2C71TfXLIMEyfRIJyy4wVlRlDtJ0xTl4koMhJus7UPh1qkHy9xZjb40cgAvjryE/+m+Xfj7G3bi/zp7GH9y7kUAwJri35izfinKXKKDs6IsAsLSKvazgXDjLPbEpjUw788GZgD40vrWv39y7kXsWlrA5+domZeizCULIitVR/IokSyKQb6xARet3YmBhYXjongnXLO6ECRZerrmLyvwOHf9bV3lS04GdZev3ORuyb40erSTTF2+IBo8a4+RcCWZqLhI//5wTVZeX3wCV6rvAPDx+coX72jvo+qLGEnHsbbyNADgfPJu9tl4zWTMasYmotdeScD9Vu1/H4l87TP3quR3kBiYcPta/RRktOqa7/N0+4L2rOuVILp/XK9v1zwBjs9E1xwHjcaV9n0QoG/OiqLMGasqT7KfPVzZjdNpdx50itJraLS2oiiKoswzelfWLjJzaALTjW6kZZQym7L29LHY78FAPXxjxlSElXYdfc2d5T8myp77PV2lbO64EljTEnZ7vle2BMsUg0kZ6Uq7aQJrxQJjKuLqKU3r0PZLhcHc+jTquxlXzXZynfIR9JLphfw6nURlc7+/5Fq2o8TrudvtTsyAlH2vU1WMJzY3JeL6bGT7yNWXRFmT64t9DjqmsOyWrK1vzoqiKIoyz9DBWVEURVHmGb0bECZIyyiRgnjP3TqzPV/StSQR4onLpjYU9IfWl3i9Tu9r9RdMdCRpm5OyKc5p9pgoUs77mvVEd5SyXSV0DomUKfHK5o1K3CKGWRw8kW/f3u6YVGqmv78lLxNZUDItQOtQEx/L0EcgWXKR9ZD0gfFf5hBJ3Nb1zh2YuWbJPUHvV5GU7TiN55pSkW2zDRITDxGuErugPvdMpM9tS74mvye7aqVbEfEEfXNWFEVRlHmGDs6KoiiKMs/oXVlbkD7MVdrh5A5OyrbSu9HISkYqSzm5i8D1XxIhnVdXJOFJohHZDjMR2kxkqnP7tJtMBLhEwuW9g10jcTtIPSkwxZB4aEskNPb75pwf7rs24onc7VTKprDpUa1K3Yk65n9bbuog/zex4aTy9lHcopSErtdmGw/929vhcE0ryTeU008uIpqJ9GdTbkqmZ5g8CNzqAck0j6vMz036RutTAAAgAElEQVRfdiTdM+ibs6IoiqLMM3RwVhRFUZR5xsIwIZkJwxBXv1YOx2haUd86SEOZ15duRGfeFccoS9e0iVw6TWtf5vwVg4GszBlhUHm3QaKKE0be5SOG790Ig031J7hO28n+nMzreo1yUwSi38TRu10Wrc1Nufi5dTrx3OZ8tq19ud/BcarH1ZiH21cks7d7tkqO3yWjlE7S097z97sdQX01IVEURVGUBYoOzoqiKIoyz+jdaG1BZJ2rhCOSShzTmXl+vo8rjTyUyHusDJYnoXUrjaPVge7LVFwUKSvbCSLrKdzvXCoMZeUl4easvNLbkpWLKGflG96FrDxSP5mVJyKTtjCxjFwk8jXTZ4G05hzl7mJCIpDVOZ9tiVmHJU3T1QvcNctJ5QLjEV7KprSXsrnjcpHYHNy5krRv12F865nrwvdK+XUE5keUXO9+xk87ERgbcUjyC4jqMPc/20/mGUcjw+OUGJVIpmU6QN+cFUVRFGWeoYOzoiiKoswzelfW5hBINVROK5BF5VRS4nxWuahizmBE4sXrmqrQCUeJW2RYIJG4O0jpyJosUAmNXLpU/uPMWqi0FxaXZ+U13kNZeUd5XVZeWjZtXp40KwOOlEx09+nmWFauNW6Sb9A+ktgj/eHqs1KsRAIWyON+jikN7x2e3y+feYQ4y5ECr3Sun/x6E0EfGMMezkRDAh+VzZxPRnK915Sxrf90X3Jt144lEbtGbtPjSK4LbuqLtsM8kxNG2ud+Ny73gOwavHf0zVlRFEVR5hkL781ZUe6Rd8YPwIeHHQN77/js/clDSNMUCNfPQc8URVlsLOzBWSCnWKnqCJJoQNeIbqsK40PNRXFb+7bpj3MUIZPS0Y5wLOVul6TBsw4lMNNgpWxSv+BXsnKpaMxD0jTOylF9JCtTaargm0js5ekSc6yyj+/f2I/lZQ/7Vu/ONv/R6Et4b/Igdi59AfVkmWknMH2oNW6Qb0l/tyazXRK53V66o/IrJXH0X86jGPRn5TKJcKftTTauZeU6kfkprh7h7qkS208L8PcBub6YlRW2Jz09Vn6LnJTNpZV0jTYW0UkqyTZTYbQvATMtKDJKYlcDMKtmJO27psrsQP7n5PFusbAHZ0VxYN/wPgDA92/sx1AxxU+u3oNvXT6El28ewM6lL+D5pftwcOTy3HZSUZRFgQ7OSs9Sb96AB896c54mql9BM66iEAzl7MkzPUD/l8v78ZdXXkQzjbOBWVEUZbbo3cFZEIXsYr5we5tc5GbCSR+M+QmNYGSjKQUp41hyJBo2JZqkDYKrPM7JsKwBjCj9IpX/ze9QLi5BklYR1S8iaS7HUHg/ACBBA2PRKdQaV1AqrsgGbipx1+PxrDxRMFH5o41W3c8M7cPBkUNopjECL8C2yh6M1Frf4ap/Nqtfa9xies1ElVrfi4skzj8/Bb8vK/eHa7JyXzBMjtrIyuN184ZfrV/P78NUP+l0QaW0IitvKjyTlTf7JmK9kZi+nwzN+bjQeDcrT9aMvzB7zwgkS9n1kj9dYEvc+dHxFFF6VYLESMT6nQUpY612XD26JdNgaX597jznPctoXTaVrQROpnY1UXL11qa/g6M3OVdHcr24otHaSs9SKa1BWFqL0ehTjEafAgDGolMYi05iMNyCcnFFmxbyeeXmAcRTA3Ocxnh77GA3u60oitKW3n1zVhS0BuiS3zc1QJ8AkGIw3ILBcDPG6hfb7n87r9w8gJdv7scXVryAv7FiH/77tQP47rX9AICnBu+M4lYURZkJFt7gzEkNEnmEmlZwUrbAu5uVmji/VmJ4YuEaDT69vRNvbcExXacLJFGnNBqcmwrgzvFguCUbmAEP/eWNSNIEcVzPrT9RM5LvieCNrHzuYoLztR9gffk51BpP4a8u3gLwFJaFF/HW+AGcbF5CjfStSeRxisT3mcJJYvScLO0zvt/b8dmsvLFsTFHqiQkf/hDnsvIp7wdZebJ29Y5+0nOzovhAVv7hoQ1ZefdK872rsenv/sum/vdgVj5QU5YkdpM+JdcUH5XN1ee8z/OnTSRIpiY4RN9RkFbSeUUHdyyJp//0sbqVbtY13eQs5gkQPeNmwOiFsvAGZ2XRQQdmIMV4dBoD4SbndlIkWF9+DuvCZ6ztyyrbpj7vydTniqL0IDo4Kz1NVL+MqH4Jg+FWDIVbcav6CcZrp6Y+dQupWB8+x342PUBfmjx6jz3tXQ7f3I8LjQQ/t273HZ+9NXYQSZrgmaEX5qBnirJwWXiDs0AeEUUmJoxPLEGyWJ6Tvi0pWyLduEg9nUQg0mZcjSxc/ZGtqM98/1raDp1eiOo30IxvoRmPolQYRuoVcKt2Bgl8FINlGK+dgu/3I/AH7ugb/b43J00KyPcDE2FMacQTWZn+bqx8TX9/y6SBkQ6ZdqgJyCrPyMefXWaWh3122Jy3sUaQlSuX78vKtzwjZVuy9tSxAmLKsiJZm5WfXt7q7+l6in9/4RAe2HATv/LM40garXDX337rKN4YO4q/vWYfnl+Z4N1TRga/EnyQlRtNIv9LjCccke2bH9HNysWM8YgNF/VtymwaTS5lrCCSXNKOqxQriQCf3s567nN0kG5WssJF8jznosFdI99dzYA6YeENzsqiIU2BQjCEUnHY2l4stFy84uTec8rOZ14a2Q8PHnYu23fHZ9+8fAhJmmCZ17032Z9eswfb7xvB137QUg3+yRM78NtvHcXX32wNzD+5ek/XjqUoSgsdnJWepVhYcpfPlgHkjXch4cHDSzdbEeSfHf58tv2blw/hzy8dwE+v2df1Y/7KM48DAL72g6P47TfeQz1J8JWnd+D+pg7MijIT9O7gzBmPcLKGJUFzxhDtZWoL10jCDhbpO7XTSb+slIH50e58SjySxlHgrc1B2/EtEwTz+zSJvNwQRU3TD+ixTH+iBo2ap/v6ufVtqZRKa+aNPUmqZN9ifn84mRXGJ7wMI4//1Nq96C8A37m2H49ereEfbvoc/uj0q/jzS4fx8xt240vrP4fvXjb9KdWMgUne+UxSY14y6ZlzOd40PuKNSR9ffuSJbGAu+T5+accO/L+vG1215tWycjM239v6pkTN4NIjyiRWRuYlcL8V/X34dJCSe5WZrpH4abOpECX3RwcR2sx9zFZvN7XViae0o8Qt8fSXpAy22pRMLwimSpMZUOl6d3BWlEXMF1a21lz/wen9+OMzr6GRxlMD884ZO+bvHDmaDcz1JMHvvHMUG3D/jB1PURYz6hCmKD3KF1buRdEL0EhjFL1gxgfm33z7CH7tqSdw9R/8PfzTp3bgG28fxV9fUfc0RZkJFtybM2foIPPKZWQ2KtdSKUPgGcxJ5T7TnwTtIyjbyuxdSstGEXn4OkZ/Wl1H/rnhDGBEMqjI+zg/pSM3JZIkdNqEi8Ql7dDtjlMrNMr5Ij7JykdvrG79O34QjSmb0UYa4xsfv4ZdU0FiR0bMfPu1xOybt0qAnuMLiYmy/uvzrcjtY9UXcax6BD++8gWsrO3F//EqsBwP4MdWDOMvruzH8bEE2yq7cS4x3trNmES1M7+J5DekJFzEMht9Tbcjtw67QoOZyugorSDB1ahEIllL6oueg3RKKue7s204TqHJfn9BHUn0tSAFsGt6XdH2Dlhwg7OiLAaOjh/EOxMH8GMrXsAXVu7Fd68exLenbEZ35URxd0KapvjxlS/gR1ba9qVfWLkXpyZipJwtl6Io94wOzorSY0wPzE/278vmnr+wci8mY+DQSGuALuPZrh1ve98e7F2ZH8y2rXKnMYmiKJ3jpT36Z2+xwGQc6pKna0DMI3zf/A1D5TqrSYnszNSXGAaIpOo8uca1L44evhaOKQAl3rQSeZydXqDtcBI0Kxfmm1ZQJO3QyGDq3ZySCGnPK5Md8qXvUmFpVi74BXjwMBBuwpBv0kfWMI6b1eMAUiAwbVIv8XZQz/clFWOBuiLYmpUTEkV+rWkk89HI+HlTidjV55n7zW3Zub1sm1pGQvS6NufeJwYskikOyfXCXWvsdA0DG/UtoUurTdo9p+jn1Aue9p1OpbD5DiTe2hyOq2DYVTzsDm6+343mNaf+cOibs6L0GIPhZvazpZUHAQA366dnqTeKoswEGq2tKIqiKPOMhSdrE3gTkvZ/kwRM+riY8YB2plup1gjT/q4SX3BXuZsiSVM3V2nW+FSCrv7I7duxry/murDkfUF6QoEhTOD3kbJppxmblI2c3Ggdqt35J8cvBuaYNGI9tgw98qOpqe8wva84yZqTfNm0j/S4xGHG8wJSR2C0wxiV8BHg+SYnVrpZgTmFRAZ3nRpwxUk2d03veK+pb++23bU/tLpk1UoH/Ww08j36XdE3Z0VRFEWZZ+jgrCiKoijzjN4NCBPICxIjEc7jlsp1klRsHclOXYowzyQ0R3mGi8pmIysFsOfD1V+cYBtGMBGg9FDOvsntI7Tt7fn+21YkNjVUtjpHrzsixTL16XdpEi/xOMn/vVjTBddI2CkaRDKX/IZU2nWONCaw0jsjR9qSJV1ZETB12k+t8FI2hYsqJ90UmOJ0YtLSyXm2G2ojJbtGR7umBhV4h0vMVCSpe0WSuEBa79q5J+ibs6IoiqLMM3RwVhRFUZR5Ru/K2gJ4b+r8+jQ6kpMpioX+rEyjVuvxWO6+Ii9uAo1mzfNBBsBLK1P9tyN1iRRMooU7ihZn6CSKW2KEwqcDbS818xI0bTO3axbscQU+60iNtErTQdr1ubSSFOoNTrdzPs53v81dJTmaZk+SgtCaLkryPbclUnCa5Bu0WMciUwpUyubNRuixJFHZaFtHYjbCT7mQ/giMdjgZXNKm1R96/zHPx+k67HSXYNqskyk8j3k+S2Tqbkzt3K3+TKw80TdnRVEURZln6OCsKIqiKPOMnpW1qYzgW57FRAZlZMpCQHyzGRkxIfJYpWQMT8JgKCs3k1pWnqibv3NqzVumD4mbpJNwElAbKRsg0g2N4ObMMay0hmS7JBJTEOltVXdMfUclTlFqPas/3HYmDZ2jrMXKV0yayDSl8jUnuUtoL9fT714qDJj+UIMEEnU9Lb9SIxPufojJtU7PZQxyfTGpOGVR8/nfLyHHBZ0KsKYjqKczMR4hcL+b/ftQuN8nf8rK+h24aSXG2MSWr/P9wCXSOmdawsnjXNpaNiraIUpb5MvfwcoNScQ69/x3TvvYQT87Qd+chUzWLqBau5j72UTtLOqN67PcI0VRFGWhooOzEA8eqvULGItOWdsnamcxUTsriyZSFEVRFAE9K2v7jEcvJ00USArIUmEwK4ckFV/RM/7Bk7F5Ew68IgbCjfA8H2PRSQQoYWnlIYzVT2OidhaD4VakXERsBwvYWYmGkQ+zYznKM5wPM28A0b4dims0MBftysl2fBR3fgpAWwrOl7g5GZGPEqeVqCkGrUMl1/ZmFny0eXuZ2JoeIXI3XQ0QTEUw02mecsFM29DfrRaPZuVGk3h4J/lTKNw0gixdp4HK1Pa+5EtZ0bfto7hpm54l47f3zbbJ7z+dlqFmLPYqgXwZnJe76TUuuE65VKuC6G7rfs2Lxhekg3WWsrmpMknmB1e//k7SUzLtcFMEndCzg/Nc0F/egJLXj5vRR7gZHQeQYDDciqFwK27Vzsx19xRFUZQFwqKXtcej0xiP8gfWau0iJmsXrG1LKw+hddoSAB6Gwq0z3kdFURRlcdGzb87conLOQ5XKOUW/kpVLno+r0VH0eUuxItyebT/ZOIlq/QKWhA9aUdlXam9jemAGUlyffB+V0hrLkMTuqGCBfAd+s+yx2rXBpj50jBbn5DPWo5uJmmWiXbk6NlxUNke+LJgy0iEnL/P7cmkI3frGwvlyE7mW+m/TqYoCSf1YKramd1YWH8q2rUjWZuWEfNdrJfNH6oh/OitX6ybamZPS3c1aOMMNI0HTKGvbm5welxqS0KjsYm4dTkKXhZPQa4r2gbu32//OrBwt8OLuhLZyt+Q5wjyf2batVRaM2Yjk2SSY0pNMj4mwjuu2q4SeHZy7xcrKDgDA1egoAhSxJvwMLkVv4VZ0HEvCB7EkfABjzUsAgGr9EqL6RfSVN6C/vAFj0WlE9VYEt+9V2GMoiqIoiguLfnAGzAB9KXoTl6O3kSLJBuZpbh+YAaBSWgMAiOoXUQyWoVhYNvudVxRFURYcvTs4CyKGPYGk2ERL1lpW2Y5r0XtIkcCDj4FwE+Kpz+rNMcRxhGJhOZLUw1h0HgAQT0Vl+n5/qxxP3HmAbi14l3hht5NNBRI7l36P+nKz0eUCUwNXA5OUjfSl5Ec4FwJjxEGNNmISTUvlX5F0KDGDYevkS+USMwjL1MPySCfSLQ3pp0XSfiEwCs/S4kYAwM7yI9m2Z4bNjpOxKb95zfzh+RrMMRvkmqfnNUG++Q2VoK3fjZOymUeUlVqTMQOxZercZm4zLXHz0JatAOAese3rSFYSSExIKNZ9JpmWafNM4QxUuONIoq+dpWwBdrpZzsf93qf3uDY7YdEHhE1zvfp+NjCnSDAanbA+LxWHUSosz9038AcQkIFAURRFUTqhd9+cu8j16vu4Hr2HVeFTWB0+gcvREVyJ3gYAjcZWFEVRZp2FMTgL0oQlqakTEe/rc7WXMFk/j77SeqSlMi4lx4BSGcXmcoxFJxA1b8LzyqSdDtIuunq0MhKz1WSe/CKR/Dl5iZ4/SyUVRJeKUvG5mgSYIp+KL1/yo/WpZ3TCpFbk4KO4aZ32cjc1pMgzA7m9ferv3oxNqsU4MSYgbOR2bm+AYmBSnj6SPgYA+MfbzP3w5C8RBahgJN83vmHk66+9+3hWfjkwUdy1hmlHZprSXuO0Jfz8Oh5K+R9YphgCCd3Pv06567ddKs472pdMj1hysCly9V2lbHaVC2M8QslSRkqmtbhUkgJcp8G455plrkRMqKwpDkm0u8AwZib8txe9rJ0iRV9pPfrK66ztpcJyFAvL+ckqRVlg/O8nX8HX/v2LuZ/90elX8YenDs9yjxRl8bLoB+f+8p0D8zSlwnKUisOz3CNFmRsCz8ev/z8H7xigv/bvDuIPTh9G4GpvqCjKPbMgZG1WtqESIYmmixojWdmW4gxc1DffCYFhh2CRPieJs9GDeccVmWMwMOYortHUvkDKtqQ6KuExhi6JQBKn/bSih8m+TZI2kU8lyXmMc5Jefn/oeaD+7jQN6bLipqwcwsjKEzDX6a3GObM9upSVm9Y0CzHmYCOMDRv6WnL6Yz/Ukqb/FR7C6omN+PXf/o9I16/BV778s/j6v/j/8NU/OYB//vwO/OrntgC4jBUfmyWGfrO9zM+nzewOtH0uZaTtuc0YZDBTVimNQia/IQdnTmM/bhmJm5GyOUlc8pxiV7AIchJQ8ry17QM5+lRLpGBB5LvHyNRWJDmNpmbqcJK181jQJRbE4KwoSnf4ypd/FgDw1d/+j/jNf/lnqNeb+Oov/xx+ua6PCkWZTVSnUhTF4itf/lmUSgXU602USoVswFYUZfbo2T+HUy76sgP/aNomjaad9iAG7BSTdWJgUa2bFJN0Mb7VZ66fHAL5KC/do0SOdk37yNWxpaZmfh1GOrLS6Un8dwVyvR1NzxkDcOe+vYc2J8tyxhO0TFOVbiw8lZV39W/MyltNFVyOjMb56o2Hs/KR8n/LymNVKtFT+Zj0mJyTmPjEn5lsRYBfeM1Ei9/3ty7i63/w7dbAXGwN0N/4+p/gSx+vz+pcq5EocjZNpIEahqSCCG13qJxPjmtNNXBmQPlyN+dZngquKTtNJCOnS1ZfsFMobr7cIiQGRe2Q7GeZqTDPZEe5W7SdqcP6+DMrVdjzOgPxGPrmrChKxtf/4Nv49d//K/zGL3wR1Xd/H7/xj38Sv/5738K/+eSNue6aoiwqevbNWVGU7vJ7x9/C7/7VG/iNX/givvK//BgA4Cu/8DcBAL/+e98CAPyvDzwzZ/1TlMVEzw7OkgXvtgThJuOWi0uy8srytqy8PtmclasFYwxxKngrK9+qmpR6rI8rI5VIoqv56Oec7RIva4H3LSv/sJ7I1OPapCm0TDZIVHYzncytY0f9ctMUbj7YvFlKe29tux036ZBOiTxa3JCV/8HW0az82GcuZ+XRc0Ye/f13NmflU9fuy8oT0cWsnMBI1mCuqXpzLCu/V2pds19763kAwFtj/fi5dXvxyGtP4c9fu4yS32rjSTyGZ4fG8NLlBLVoNY7i9ayNRtOYk9jnNV8iDoKhrBzHo+g++akhOS9r3gebm8q4dzMeG65NSfuOftqciYqrOUnbjrV/xvpov4rDGUn6yA4Mo0TndQZWIfTs4Dzb3Kh+AMDD+vLmOz67EL2BifQ8+sP77vhMUdrxh6daa4j/4abP3fHZ737wDuI0RT82z3g/PjO4Dz+2Nn/e+pmhvTN+fEVRDDrnLMbDSPQhTkevWlsvRG/gfO0H/EJXBQDQaN5CM85fU96MR5Ek1Vnu0fwh8Hz8wenD+KPT9rX1ux+8g9/54G0Eem0pyqKjZ9+cRd63Ar9YLqK7RDyIVyUbsKq8AefSJThdO4yhoITH+/fgrfHWwLytsgeN0JhKjPtEamRkbVFKN6afPjXIyJOjGKmG7meld+O8ZjuRnUg7xUI/krSKeuMaisEAKuW1AFoSa71xHXEyBt+rZN89sX7b9hK3c9c4QwrGo5uTa20JLf8atKYsSLkcmAH3lx99HH2lOv7l8cNY+1ENX/nRp/D177yN3/ngbfyzz+3Arz73CP6NCdC2PcNJZLCXEBmX9oE5b6P1lrHJd/GDbNvRT7aYtsn5OOcdy8o3o1NZmcrk1ioF5veZGSk7nzQ1006WqUxCTUVoZDW9bzjvdjdzHT6yWiKbt782JUhWb7DTbDnPKfYZ5bpShtuXwnl0dyJlczB95lJhOq++caRnB+e5YEP4HJYGId6dPID3J19EghjbKnuwrbIb76YfznX35jXlYuuPl2q95UZVKa9FvXEd9eZ1lArDSBa5hfkvPvg0AOCr//UN/OZ/exv1OJkamB9vs6eiKAsRlbUdebx/D3wESBDDR4Btld1z3aWeoVxcgUppHar1C7gx9lY2MKt/eYtffPBplAIf9ThBKfB1YFaURUzPvjmzEq2j5MLJEfXYRKGOB0aK+8HY20gQw5saoN+a+D42hp9D1TM+yDQK2VlmEdTnZNPp784bdLQ/TyIDEwYu4jOOzXFLxeWo1i8CUxG8QTCAOKndJRo8P+qYyrmcbMtHcXPR2vnHtfZN6Lmn+emIhEpuKzqtMVm/lpU/9m5m5b841ZL5v3P1IOpxgqIXoB7H+NJ/Oo+fXL0HAHDgkml/Irlq2uckdyZ1ZrFgpmt8vyWDjzZN2sebiVlpQNNUpiQKumF5k7tGJs8Nlj+2KGJYcH84RvfL3oXypWzOnMRZ4haYA7XzmxY9I2Y6SQrnL84pcNxzVfCM9Tmf/Rn+jj07OM8Fl6MjuBK9jQfC3Xgg3IkPqgdxpvZK68NKe0N8BYjqV9AamD0AKRrNmyiSJUaLle9cPYi/vrof//N9O/Hz930ef3L2MP747AEAyAZoRVEWDzo4C7l9YAaAjWFr6cuZ2isY9LZgMNw8hz2c/zSaI2jEIygXVyEsrcJEdJZEcC/eGZbpgfknVr6An7+vZfLx8/d9HiONIv7zpQNTtZ6fs/4pijL7eGma9mQoTrFgoqOdfaq5lGGMHNxXXomofhmAh2V927PtzaQl703WLqAej2dvgI3meG47ktRjIoneAfaYEnMSQTuSxfcefCTJJJK0Ct/vg+9PSatpkm33vBC+X2nVZwxmOAlXJilySDyO6bE4b2WK0cc9z0RQB74xY1natzUrl+opPPhYFz6D5TDm2uf8i7hSPQogQVw07YxHRoa201+Sa4ecw0ppdVbeVDFrqdckawAANRiv7Ev+2aw80jQSd4NM81CZvExMRaKmkeona8ZMpRmbiG7bJGTuoRK3/Ry5dwmaPZbAV5qPbG7vsy0xJ+HuFdGKl+n6AoMOq4/Mc8d5mo9pM2Gue5HxSLfS+5LtjaaZvuoEfXMWEpIH3O30ldchrV+Zxd70HikA36uYgXkK3+8DktvmbxcZ68Pn2M9WVXYAAC423+/Ksa5Uj8CDh5VT7VLORq9hzLuJ5ZVHunIsRVHuncWrJSqzSuD3tQbiHFpv05VZ7tHixIOHq9FRXK0etbafjV7DmdqroG/9iqLMHb375iyQO1jJhZNlGKmX+hdPeJdz61hyiiAyWOLX2o3F9a7+uSJzlA4W+qeMOQb13+4rryJ1jAxK03I24/ypA5mhA3K328YmdLurFGtUgDQ1knGcmOjn0ehcVj5WNLIvPc/U4KNBvi+NAPcsQxITlEjbqRSXZeXPF34EH2EpjkWHMFEaxrNL9uL71/bjTO1VPFLZi77y9qz71cCsQKCGJF6jBsDHqsoODCdmeula+QquVo8iRYqYHJN+b/scz71aklKzkZROR5RzattQYxPJdQQrSvzeo7LZ1JxM+luPa8f1eTBVhzUy6eTZ5RhNzU1Nsm0SqOSfoP3z2Tofs/i3a+8Ozoqi3BMPT63Nf210P14fPYQEMR6p7MX2vt04HUvmy3xcjd4BAAyXfyjberV6FFejo1gZ3imZK4rihsrairIIebiy2zLT2d4nN9NZVdmBleGTuBq9k3nNn45ezQbmvPlsRVHc6N03ZzZikEmFyKVf5CLxKJyELpFxHJGkYHTB7qObhGM3dO+e2wlTnxqJWEYZZP6Zbo+JnEtlbYmULUsryV0LnUQY50vcjaYxtqEyNR+Rni93cueQttkgSUWuT60wOBO9mg3MCWK8Nb4fW8Lncck7kdUdr5spHJruciAZwkB5F8ppGadrh3Gm9hpSxFgZPpkFsHFR8zR63Z4umA9R3NRUhppNSFK3clJzvvQtwdXkxMUf+3ZYGTynTVby5Z5dktmLDqbHuO2SFTH0/rHuPYEsrykjFUXpKuBeVq8AACAASURBVGeiV3Gm9goe79uHx/v34JXR7+Fk7eXWh5X+u+9MWB8+i/O1N5BOOeat0jdmRekaKmsryiJiemDeWH4ej/e3nMe2hM9jS3knTtZexmj0qbit89Hr2cCcIp5ak60oSjdYGCYkrrialnD7dkniaLvo/2518rrYiYRvNSSQrAR/36WMPOtbkp+hTCJ9KTR6OU6o+Ub+7+Asa1ue5R2ky2Qh0cAIyGY333f6N3VAIrS5+gVaB0148FApr0Vf0Eo40khb53I8OoNGPImw1IqWp+ebenIvKW3EaPQpRqNPMRTej6Hw/uz/YWktKqU1GCPR6AkbrU1xNXqZWTzm2pSZjXAGI+0Nj1yPxU1rcJ70nCTNTj3l9E00DdZBfQtJKknJvsx9JTlnVpOC53yj0R3PC5W1FWUR0Vdex342EG5EtXGjbRu3D8wAMBTej3oyiah+sc3eiqJI0MFZURQn0jS1BuZpKqU10xXmoFeKsrDo3cHZ0QiDkyMCIl9R2SlhzDJY0xKB4QnbNyb6NhHI3XnH4tKacVINm36TPGNdI0F5+ZKLoDR9qzWM+QUnicug0fpc3+h3mQkpm0Iit63IYBOp7HlE7hb4KXPXCCeVxkktKzf8lpzN+y2bcjM2Ed+FoIIUwK36GSs9aq15KyvTaHG779y0A6lDzTqsKO5uDfr0HOdHids+5ZzEnQ8fSUzPMxfFzRnn5P8uRWLeUyoYX3Z6XUR1cz9xKzaovEt/o0JgpkSmf2vLVEZgpsRGf3P3s6vBlGN9S86n16lgutP9GXTvaECYoiiKoswzdHBWFEVRlHlG78ragrRlnKxBpaBy0ZgrFIjUFBP5olo3loZNIulw/bH6wKaAy4eTAyUy/vR35KQjKl/T88GmqWRTa9ZJWeDzK0hlR+EiR3mZ19q7bX0LR/ODmYCXsrnvki9x0muNTtcEvvGJpgYvRW/qPmD8grnfgf6eVCYHGxGf3z7F9nzOl0SpiYurxF0oLCftmO8Vk1SYtsTNmSi3l5r5KR2QOvlR3Db52+2o4vZlexqk/bOSStk+NY3x2piQCFaDsNNgtE3mp5VMHUqet9y0X7ciwLuFvjkriqIoyjxDB2dFURRFmWf0rKxtySCclMHIssWAGCoUN+Bm9WMAHlZVHs+2R2h5N49UjyFNI4Sl1QCApG7aTwTHkqSMZKMKOe9ughXdnSOJc31hJSJGtuFSpXGSHC+rdSva0VWOlqSPnGmMfC2JygYTfe0qZVOZshQMZOUBb3iqV0a6HA9MWk56jcRW6ksjZdNobWqIkjCGLvbvn/+bcJI4NW7pJIqbT+nIRHE7eu5L4NOcSqZl6LSCuedrDRItzxmPkONWSsPmSGS7bfZjfut2cn0nBiMSKVvyPGQla3pYy3yl/ZSeRKL3Z2Ao1TdnAICHW9HHdySgH6kew0h0DPz8k6IoiqJ0n559c+4mSysPAgCuRq3BeWVlRzYwLwu3IQn0NCmKoiizR8+OOrwfLYGJpvNyJOhllYdRQh+uRu/gWvQeUiRYFm7Dsso23GicNE0Koh0li+stGYfb7ihl50VrU0Qet0wUPCc7sdGatElRRLdE7izk1pFEwXPp/VJHSdQdNynbnibIv2Zp1L1vGUZUSDlfyg69JVm5Lx0CAJRTIoFT+TwgJiSpkTfrnknXyf62KZUOyXeiAb2MCQnrR02juGl91jzGKF4xSdFp1SDRyBZkHodeI/ZvSKoLPMNlvu+SR7I5J9QQhAr93KqIUmEoK/cXV2flgJwHmoyVStzTv4Wf5q/6kKRZdM0XIJKyuecad9xOvL6Zvs2EOYnK2oRVlR3w4E/9eD6WVbbNdZcURVGURYgOzoQr1aNIkUz9NZVgpHpsrrukKIqiLEJ6VtamSFIuUqhUM+5fAgBM1i5gsn4eg+FWDIVbMTL5IUaiY6glY0gF0eASj1lJJKEEKmVZUbzpnX3J+/x2JCkuJeYBEvMFDpl5QH5EL2/WkC+PJgk1s8j3Vu4MKmXny6aS79stKbvimxSc/akx3RlKW3VC0sdyaso0OnrSI7IwPd3kCVL3jaEHjfKlvtyUvCkZ4G6mHARrKojz4s5/FgS+MSEqEEMiCjUbsvrJTI/wvydnTtJe7vZpqk+ybyLoA9emlaqU0EyJPE6+bzO+00fbOcUtI9V3lD6SnA9ulQB3LNFzWCDRd5ImWMKCGJw75faBGTCp9Sbr51EIlqBYWHq3JhRFURSla+jgjFbAR19pfTYwTzM9QNfj8bzdFEVRFGVGWBCDsyjymCxVplLNWHQB01Gd1yc/MvUt+SK09mnfIWaROyN9uco77SI62RRtAg9ySYpJexG/xCM4f1+JJG6fs/bewbz0TZlZKdsnBiBUmvSsKNtJs50xFbEMRnzGK7tgDHVKvimHPonK9ozqM5AMke2lqbqm70UrsnqIbDdyd5Ecn5qWUB/mGowMzvo/e9TEgRyWlflN2fLrJtu5VRCFwHyX4X4T6LkFT2TlMjFjOeN/mpUvV9/LytX6VdKHfPmauz+5qGxuO3ev0GkNLrUtZ81Qa5r0kWM1ej3WSJmT8dtgeejnR3Q7P/cEBjCssZEg/4LEH9s1XW630IAwRVEURZln6OCsKIqiKPOM3pW1XdN70V3BRD6m+XXYNgWSC7coXiTp3KNftygykeu7Y/o1n5PwOMnakibby4IygxG3FH3dwiO3j0/TkBZMdHSpOJiVqXQYERt0Lvret2TtfCm7HJj2qZTdD9OHwYREaMNEd1eClpwdErORkMjaQWx+rDAhEd1JvmnJmE/SC5Kpg4DUoZND9Hejv6AnMLNhUzRaUwRGWh0I12XlHy7vzco/s9H0c7BgrpFvX3wqK/9n0ofz8etZuRFTMxbX6yvfYAbWsynf95mbSrLOpyCta615i9Tp7v3B+fhLnntsfUm6xk62UwQrcTRlpKIoiqIsMnRwVhRlUXJ0/AD+04UXcz975eYBHL65f5Z7pCiG3pW1JTICIzsUSARtqWBkQSpfsOnXJIYnnD+1499CrJkB0+Z0mZOFebMLRkZmomxtaTo/itRun4um5vqZnzaPMxXh4L5L17BkZxqV3QDgYSDciH5/RbZ9IrmG8egMgNRKW8pF4tIIbctghERlWwYjRMpempjyEs9I7stKRnpeWmqdw/5ifmhvFJso7tG66ePNutleiIncSq9L32yPiIFJk8itVjrChF7T+X7KqSC1prWVnL/lxS1Z+YU1re87ftnHf7hwAA8/cAu/tnsH/Erre31j/xEcvvU2/sf1u/HDqyO8ftMssbzkm8x1VNZmZXYC5yXPp12l0nC+9M3J45IpAGquQs9VO4lb4nfN+4jnPz/tZ0H7FS4iOjEM4SRriSTeJXp3cFaUeYuHidoZAEB/nxmcx6MzmKidQX9541x1TCH8D6v34smHR/Abh44AAL7yI0/hG/uP4Kvfaw3Mf2/9rjnuobKY0cFZUbrMQNgafCdqZzDi9WFZZRtGqseygXkg3Di1vl6Za35t9w4AwG8cOoLfevld1OMEX/3hp/DcmA7MytzSs4Mza67BSBlURiwW+hDVLwPwMFB6INueTO07Hp1GmkQoFYcB2F7crgkGO0lJxrbZxsyE97UVRGgLjA8kPtuyVJLt00RSeCm7veRnmTJ0K0sk6b/ld+2FWFp5CL5XwEh0DDejj5EiwWC4BYPh5lZ9n9RPQ9KOkZ2plF30aZQ1icROh7PyktRsHyb+0StCc6wN/eacPD/c8rzet++c+Up1c3K+ddBIwZ+Mm36dmyR+4cZLBY3YRIs3PGJq4Zm+U0m+6RvP7SS592hhPvWogV6DAXEqSespfvWzj2cDcynw8U8efwT/5aA5Z1XQKS7qy07aF0jZfJ/b+2zzXtxcH9pL3/a+93j+uek8icc18/24fomkaUl/OJmaNiOR02cgQpuyiAPCPNQaVzAWnbK2jkenMV47ZdsRKco9MBRuzVKQevCzgVmZX/zm4aPZwFyPE/zWa+/OdZcUZfEOzmFpFcrFVRiLTmYD9PTAPFDejFJh+dx2UOl5RqMT2cCcIrnjD0Fl7vnNw0fxv718FP985w7c/MW/i3/2/A587ZWj+PNLh+a6a8oip2dlbYl8VWCiXacNHfrD+1AKBjAWnZh6cKYYKG/GQLgJY7XzuW1KIhVFCNKrcSkeXcxM2BSXTNSkqzTNyXMy39n2cjQnpzunp7SkQxqZWs+rLWuS6OPN2Oi7441LiOpXUGtcQV95A/rLGzBRO4ex6CRqzVGUisNoNE16RSs1JJG7S2QqJiRSdgXEHzs1qSGXeOYap1L2xgHT/g+tMlM0O/9Ry4Aj+aGfNF+KRE3/nScPZ+XDf2jO2UvXzAqHqGmOM1E15iQTpF91z8jXVLanvy393klMopSpbzabftHPLdNo5BuNk1n5uxda88zvThzCu5NH8dNr9uH+8T344+/6WI0H8cWVw/jTi/vx4U3gkb49OAMToU19p2n/Y4ExCDsdJfGzZ9KH2veZJFUlqSEwEMr9XCBZS1IxsgZNAn/xTkyoJPtax+Kem92aHmPo2cG5WwyFWzEWnURrItLDQLhprruk9DjTA3O5uAr95Q0AgP7yBjTjKurNVqIIjwykytyQIsFPr9mHv7V6j7X9x1ftxanxxPrjS1Fmm0U/OI9GJzA9MAMpxqPTOkArHZKiXFyFsLTK2jodYJgi5ZIGKbPIjv59+NHV+Z890rcn/wNFmSV6d3BmovKoJNIknsV+TH1/W/VrjWuoN66hVBhGqTiMWuMaxmunUItHkZIUgK4L0tlIP0F9V2/Y3GjtDoxPJFI2V991xJGkj2TTwTGwcvcMmwdQL2OkIYAUE7XLmMTV3DppSq5NMv1Co5apVOqT6zEgqQ3LMPv2BeY6GiqZ77u13/hHf+6L18yxvvgzrb70Gwmakn7pb2flz574P7PyuW+Z6OsrkTnmjRpJK0m8uANLyqYSvtnuEcMTV0MPq8/UH5+cv3GydO17wfez8gent5v6xA/8YnIsK9+qns7KNNVnSiRu+57M7RprrkHhorX7ymuz8hKyTr5B+jNeu5SVo4ZJ5cmdK86j2+WZIUlDK4oEFxmxCJ5rgvucNT8StG9NKcyAX791rBltfR5z+8AMAKXCchQLy9Fo3kCSTLRpQVEUZfZoPbOu5342UTuLevPGLPdImUkW7eCMNEWpuCIbmKeZHqC5v34VRVHmAg8e6s3rU1NxhonaWUzUzsLTyZIFRc/K2qJIYlKnTtKj+UkJmJInosZIzp4BAhIpK1pszqQY60RCkciveRGSVhQhI/NQeSZhIpZdvcNd4VPDkTqOEjQbPZ7GpBYtdwfbszjKrcNJmZ3gk5MV+KZcIbMy6ytEQv/RJ7NywsjZeQQ/89msvPF7JvL53VsmcrtAjl9I8iNuPTpdRJB4pXPwPtJkioD4YF8f/zArj/ifZmUavUx9s2nUN2vkI0BiHmKfB1MeKK0FSmsxHp3GWHQCA1iOteHTOFf/ASZqZ7EqfApJ0bRPn3ecfC3r9N1lYvY7uZ4nybOOu38YsxHu+SXJMWA/K8lKAmYqYybo2cFZURRlsTEQbsKgtwIXozdwKXoLKRKsCp/C6vAJXIzfn+vuKV2kZwdnLhE5xforWrDuz0KS0YT+dWUF9ZDAH6o00aCLbsnmeX/ZCt5yXdf3utrxSZLDc3U4+DXP7deG8tMUEimQ29l1LTc9bPu/umn/E/K2H8NYSDZJH+LE9DOmgVHkO3pj9xZL4dWMHSc5jHUcCTToil+3THdor4qxSot17ZNzQ4KomrFZ9+2RwLWU2HRacjFrr8lZZHK/s+RN0ezbJH1eUXkwG5gBHwOVTZjATSvjl63euVmIWl83pfVb390OfuwgSEvgu2DBXAudqJD0uc21mQiCemeCxTvnrCiK0oNcq76XOc8BCUaqx9ruo/QePfvmrCiKstiYrF3AZP08VoSPY0XlMVyuvo2RaGpwLpTvvrPSU/Ts4CyRLxLkSyUSSdxqkpM1CCLpg9nXCjhwtZNsI63YQQ7tA9JEa5sFGVv4TFSuwWScLM/ZN3JrG6lkSTIUBSagqVJambtvVDfLV6x1rlaQGdcfgxX4g3wZkcOS2Ui5BiM3R4lZfzzeMIFXpyfMQzt+9RNz2Ccfa7VdMRmsQNZKezUTSJa8/EFWPjWxLitXySmoE+vPJrn3qAwfE7lYIr1S2ZFep8WCCdika8MbsZHtm/TapMe1rh2SoSrlAgXp9V4j2+kUDWnRmhLL386Tf42PRRfQjEcRJ2MoF1ehEaS4WH8XsZegVBjGSHQMvt8Hn2T9Mn24exa7278A9zyYDnQUrYmWSNaOXg9cO5LAVTB99pjpCDp2cFMlMxHgSenZwVlRFGWxEfiDrPNcI67m7aL0KDo4K4qi9ACFYIj9rFQcRoK8ZaFKr7IwBmdJtiUu85NjBiRuDTMrlQui+xLJ+mdBBHZWn37OSKZshLuk74IIWkmEtkTWtu0YmbWHlrTOrGekVphE+ls9aNb9Pu09n5VD38jCR8KPs/L56ptZebJ2kRyX+y7t5W779zfSapO8CTV9I1lb0cmeaX+CrBIYqZnz88m4+S7f/jNjA/kjY38KACj8nWdNe6tWmH794bez8ve/baRs2t7Nmjl+PSER5V5+dLnEjjMgUjbNYjVYXp+Vh33jfz9BBqUrk2Y5UZOsVabrq1O0XxlAsesTm1FH0w/ecpRKqLR+/rrrRpV8L+beoj4GNCOfZQ/LrMfn7svpe47L2MQ9I8oFk1GNQqcgRDbH7Kqc/Oe2xGMiJuUA1JqzvQ2wc5YsRzRaW1EURVHmGTo4K4rSM4xFpzAenc797Gb1Y/WXVhYMPStriyIQuQTeRJooF5dk5SKx7KSyRr1pjApsKUYQuedqeOK4iJ6NcnSAldIlSck58wKBlC2JXpVk1Lntk7ZthsRP/Ul8Liv/zQ1GQh0umfaHLmzLyvtJdPQZYpFI7SFTRmankbu0/74VDZxvfkDLdZiI8Uki+1JKDdNmMGHkujg1kds3/nILAOCRF40dZzEwdpbvjRjp+INR097lqunjrbrpV5XI1zXPSPK0700S7Uxl+zgx26kEXSqYaPp13jZc9CZwMXoD8DdlaR1vNtfgRHQYN2sfob98H/rLawDYmZkSK8q6Sziae1j3hCjSV7ICgMq1JJrdN1I2PZ8Bma6J6VScZVrT3uzDbMyfYgvI8YsFsxrA8+j0gpn6aDTN/cM9t7mpQ9GKEW5akFq8OmYEtPowA7bmPTs4K0q3+YvLB+DDwxdX773js7fHDrZcpor582fK7LA2fBoA8H71IIBW3uUT0WF8WnsJ95d3Yaw8s65NijJb6OCsKFP48PCtKwcAAD9/385s+9tjB/HW+AF8ZmDf3HRMsVgbPo3lXj/erx7Eh9WXkCDG/eVd2Bp+HkfSl+a6e4rSFXp2cHZNdE0lpZC8/Swrb8nKw+mGrEwjTC8TqW80OpuVqcQt60N78w4u8txK8s1FCU7vK4g0ZL3DBeeVHt89wj3fMMTuA2dgki8Xu0KjV0u+aedn1u1B0Qf+7NIBLCnF+NL6nfh351/GW+MvYufSF/D80n34r7fMtcBOAThmq7GiR0nENY1UrhPZvMhEbtPyCMkKhZrJPtVIzHV0q97q5/ujS3P7NdYwWudIzUiQow1zb4wTuXjUM9M/EUx/66mR4al8TcvN2EQO02ukmBpJlGbgeriyOxuYPQRYHz6HGppIiNnIzECNSvIzbPFZpgzUf5+XuBOmbOD2pZK19bhgnh0uWaQkU2l0KiNO8o2VuO0ULvqavd8cn2tsmwKv904y8kno2cFZUWaCn1rTmsf8v88dwH84fxiNNM4GZmX+8GH1RSSI4SNAghino1exKfxc+x0VpUfQwRmtKE/Aw3C44Y7PLkfvYCy9jsFw86z3S5kbfmrNHnzr8otopDGKXqAD8zzjQvQmLkSvY3tlL7ZXduPNie/jdO1w68P8JEOK0nP07uAskQ6ZKOhywTjtrEzvQwNXcCF6HRNYg4cquwAAjTTBJ9HLuBS9heHwMQz5rQjQyeBqtm8zMdGmNOI2ZvyxJR7dFElEYp6kY0lBkpR+jlHeEjMAMEYPduQ2lzKQyuN0b85Dm0vRl/+9ag0TZf1x2SzL+f6l+wEA74wfRCNtvZU10hjfvPTf8WDYui5GYKY1XH3QOc9lzjiFXl9ebOpMema5UBKQ7yg4DY26kcSjuDWS3ayTCFpywmvEK3s0NhL0GIkWjzwaOT5qtqemXE+MxE3la2qIYUXNku1R3XyRs4X3MB6dwUTtDJaHj6IZrsK76UdoVMoY9LbgdHQYQWMwc9JKLZONbuVoNdgrQPIfpezUlEev8XuXRzlzJTYKWQB3f08/VyTpHWmdqJHvXGb7WrdPy8s+M0XTYPTAjlNikuO6timgdwfnLrJuKgL0o+gQAOChyi58Er2MT6IX8UC4G35l3d12VxYQ74wfxNvjB/DZoRfw7JK9eP3WQbw2uh8AsgFamUtS9Jc3YrjyiLV1WtmarF+bgz4pSvfRwXmKdeHTGEQFH0WHcDx6GQliPBDuxgPhTpzAyfYNKD3P9MD81MA+PLuktZzq2SV7caPexPHoxValUG+ZuWQg3MR+NhhuRj12zOqmKPOU3n3SiAwsGKmE0CTRl5vLz+PjqYHZQ4AN5ecQpQ3UPRptykjWXOSeYPG7JPpRErU4XUeSBpND4n1tGWhQkwDm3HiMHy1v1sBFbrul3LM7YY5Vb97MyqcmD5sqaKC/vBEXgib+dOptGQBqhXGEpbU4Gx9HMmH06CQm6SPJdSRLQ0r7mW8k4aXmPFDDDnreapafuYlUTnxyfZGI9EJCTCjiVh+KsdkW+sTPmaYsJFL2Td9M7VRTM0XQJNHXtdjI2lYaR2o8QqYFUiYyuUlSdN6qmimIcf9Sbpv0t3X10JZhfn9rRUKaH30dFk0aUmrGQe+hKklJKoni7kgG5wyHBPXbwbWXWCsQyL3NGXe4ysWOcveMoN7aM8un0ctIpwbmFDFORa/MdZeUWWQg3ISBcGPuZ5XSGlTKa3M/UxRF6Ta9++bcZS5Fb+FS7U08UN6F+8Od+Ch6EaemI0D7hu++s6IoSg715g148FDMycxUa1ybinjUdyTlThbN4Ewll5jIf6PeVYxUj2EkOoZl4TYklRU4jo/QrAxgyLsfp6LDKCcrUZ6SpzhvbVb+EfiyShbOs0YFeW06RjjKUjcycjRjSMJ5X0tSBrqmleQNGqhsTjtBJUWT9pF6MVO41JOpZUiRkvrm+qK+xvZv0d5/OeFkX9od6sUdkONSIw/PRGiP5lwPfakxKYkTY9DSJMekUdlUyo5iE4nbINHljSZjPEK/k5UqkYu4NduttImknJCo7NQxgt6d9n7atFwIyojqlxAEZQwWH8i2j1SPod64hv7yRsTk4qwn9Py4SaVcSlUnr+y7bJ++Ly2zIev+pykX86e+7AO55R2wO9OBAZCrSZOrj3eX0D/ZAKRIsSzchmWVbdb2ofB+DIX3W8tLFEVRpISl1QhLaxDVL2E0arnLjUafYqJ2Bv3ljew0iqIsmjfnu7G8sp39bCi8H6ifm8XeKIqykAhLqwG0BuXR6ASml4PpwKzcjYUxOBM5goseTkmdgHgWJ0SapNLEePNyVqaL6EVStgRBVDa3GJ+Nspz+jow/t7UfleGIMMBHuOe3Y8nXTPSlqzxnS+Kc2QjXJleHk00buWUKlaY5Kfu2VknJlCVZ5ST+4VYPYiJrk/5TX+4JGLm+QVI55naMfKXYI0YSnpnOoT7fdSsS28jL1EAlSfPNRiSR+Nz5sNuhZ2Rm8QS/Yt79GZZWI6pfRusEe+grr8vOC38e7l3Y5HzuuemjxJpCu3sd3k+fMVmSpGLk4J5laX4dSTsWnJ82M3UnerZ2CZW1FUVRZhg6MAMpJmqqxil3Z2G8OSuKosxTovplRPVLGChvxkC4CePRaYzXTgEA+st3+vkrCtDDgzOVX4tBvymThf5UZqMRo9WG8SamkliTRHrWGsbMgDPX4Pojity2dhZECUqklRyVlW2DOQ6NELa8bwVRqtx2iXzGRoOz0ld+dKwkNZwd0ctJ00S+JPvSiNSEGGRw8DJovnzJf3dGDmY8mmswEdWUumckaX/quIVCObduwyP3DInQpgYj1JSH3mOdSNnc1IRt+kGl7JmWtbmIe4MVNQ9zTsarp9CMb6EQLEFQGEC1eR1BYQDFeDkma+fQiCeROAacSu4tV3w/P9I677iiKG9uVQb5qpJIb8nzkJW4Hc1J+NSdZFdJCssu0bODs6IoSi9QCJagWLBzZpcKy1sFXQmiMOjgrCiKMkPcPihTpgdobn29srjp2cG5EBizhMHQZI0a8Fdl5UZqIkZH6iZ5RVQ30dc0ElsiI7MRfR1ISpY0xURFcxJKuyhBVy9dV9pGjuP2aQEqTebv6m6+4HjurUh1Oh2RHxkskbs4rDaJmbBHoqk56ZYzKqH1udheKjFT4xzKdNRtLTBSN13J0ICZFqolRsrmpot4gxE3Qxo2yt6qP4sR2l7AbM//fej3pdNj9eZobh0u1yc3XWPdN2TWhErT3FScPSVCiqRNKjEHPi23pj/o9SSZ8rOOzzyPJOYe3DSbSOJG/nYaeR4TMxtWZu/E/MSRBROtPR6dxnh0JvezW9EnqNWv5n6mKIqiKPONBTM4Ax4mamdwo/qhtfVW9AluRcdxW3Z7RVEUpQ2N5i004/zgwjgeQywIilTujZ6VtSmBV8SSyv3wvQAj0YcIUMCKymO4Hr2PW9FxLA0fRuznD862ZDED0XeCReus9Owop2f7MgYj7Txzb6eT9HJp4haVbbXDSH58ffo/ye+WHw3sIV/iThIqC3cSwEP9t2mKSaovSiK3KfnXhe9TM558P/AYLUm6Rh6+QZBv0BNbZi3mmE0iBVJsmZcxwWC/HxcNxdQyAAAAIABJREFUPB+CpyTvM5xcy+3LTWW43gf59xxF4ltPpV4vKKHeuAbfL6Gv2Joy9P0Cao1riJNx+H5/Nu3DTi8xzyMJkohoS4J2XCkTp+b6FXn6d2Ko4siCGJynGQw3o4wBXIvexfXofaRIsDR8GEsrD+F67fhcd09RFKWnKBdXAADqjWuoeiVUymtRa1xDvXENpeIKpGn+fLzSOf9/e2caY8eV3fd/1dubS7PZbC7aSInaRqQ4I2mkkTQS2fRMnGDGlicY2EYSIHECI4AHyCAf8sWBBoLgGScfgmTggQ3bSAZIABuOHRvOKKPxGLa5iuKIo5VaKC5auLO7yd771VvqVT687rrnsuuozmW9Zr/XPL8vvKx369Z99arqdv3vuf+zogZnAPEbc/svHx/rKvcvd5cURVF6loUBulq/OJ/FLUKxsAGlwgYruFbpLD07ONOI0WmS9m+ieXJ+YPYAtHBp5ihKhSHUGka6k8i1XOpGKyLSSh+YvjhdFC0tkUqYFJPxdsb/2zVam/sekjb5lHXpUiZ37iVR3Pa+EimYfkcu6nsp5FTq6U66g+QoUS5inG4v5tbE5b5icg7yKlmdQCOtF+jHpri8NuqPy6P5y3H5Suu9uEw9tK1rgRRbLS4a3WDLsEzaVMt3njEE7xCe4NHouqqAm07J+cY4iX5f17SrkjSRrAmQdf8tjoouFzai3rgKzFuQLgzYIgTniXt+clKzbXiSLqezRk+SqUyJSdQShDT17OCcxILc0le8HX2l2zAdfIJaYyFKe0V9VUVRlJtG+zlqvMFrjTG3AVpxZsWMWNcPzABQKgzNfzaKnL8aOfJmoSiKoqRTa4yi1hhFubgZ5eImzNUuoN4Ym/9U55yXip4dnKmsUa2NImzNwfcqaLSamKzS9c4+fH8VWlELXppZBZcOkhpqcL6zAjMOSx5nIgwlEYPsovuUfjlL3BnSY3Ip6/h0c2Zfu89uUaq8R3d69LgVVWrJy25GC1mgx/IYIwSP8fpGVIfneVhVuhP9udvjzSEaGK+eQITIMu8p5tt/rO70d8fbnl6/Ni4PlsyPcnzcOF39XURMfMic44JJBQBr5qBFzEzotBD9nXO+6Rfny0193yNLkl8CQxKBZzwv0TOyvLWvqW+luaUNCa5Za1+BGQ93D1FoBH5Yn0WjeQ2F/Po4L3XeX4soF7ajuL0K/HlZ3vn5wqWtFTwDuWmeQs5MEdDrsRma6Rf6/SS5BziyGE9J6NnB+XrovM3iz1Zny72sKD2A53mYrZ0DAPT3mcF5vHoC48EJDJQfTJ2dPXhtH3zPwzMDw4s+e3vmQDtJQyE5UYayAokiFPLrjRf4PIX8AAB+KZ2SnRVkQqIotzarSndiVelOzNbO4Wr1fQDA1er78cA8UHkwtQ3f83BwfB8Oj++3tr89cwBvzuyHr2Y+txTFwuCigXmBQn7gM1+KlGz07puzIOqT87u1JJEsC8kF3qq27JTcH1eP7jTZx5I6KSLZ68aNWFgJXRQ1mb6v6PckSAwgbJmP+X2WCVtOT5/b8zwfq8tbAXi4FryHa8EHAFroL9+PtZXtCNGwpM+B4t0AgPsrJhbjF7c8jS2XQvzvi/vwubUBfnPrk/jvnx7FmzOv4p9s2It/NLQH/+uSmTYa84wjX4sYlVCfbXo9FvKr43K5YB76FZIgghqezMVzm0C1bhJEsF7TGSRuO0I7PTWktS+TkpSTuClN4rLFtc9tZ6fZLLMXakhDf5f0+6ZGovsXPLW5VSosTIpL7nxwaWu5Z2y5MBCXVxe3xOWiZ/5wqLbM95ipmdU9jabxlef6zJlHcfU7Re8OzoqiJLK6fBdma+eBeK3/fU77/+qWZwEAf/TpQfzw7GtoRGE8MCuKcnNQWVtRVhjtBDDtgRloYaLq7o73q1ueRcHLoRGFKHg5HZiVnmA6+AQzwaeJn83WzmM2OHeTe3Tj9O6bMyMjcCnM2LR/rmm/JFIvqUNTQLLtCxa/c3JQkgwdMfIsG0WKDNI+gYvQtuowkc9UhivkjPTpkxSGdhpEKkelS4HUa1ri42x5GVue21Q2vZlez8S0hHpbk/MwFZxDozmBZjiJUmFo3nxnFJPBSVSbV1EsDKLRND7h9WJ737HAXAsXqu3z/dPRA2hEIfLzA/RfXTqAp9YNAwAmPZPhLST3G025R3/PUt7Ijusr98blx7zH4/K2NUb6nqqb7/dzzzxoP46OxOU5ep8Tf2SZOYmZIuBSd3LI/M5vPKLbvmaZ6SkB3POCWy0hmc6Kn63cc0lw/lgjEQIrHTPPaiutZVTAteA9FL1VGCqb62uyfhpztfPoL9+HkMRNNLz0xB2sqZRgyiILvTs4K4pisTAw53P98Rr/UmEIUdRCvdmer/W88mc1AaA9ML88ug+/tmUPvrnlWfzlpUP480v7ACAeoBWlGxmsPAQAuBa8hzyK2FT+PK4Eb2MyOIX+8n3oL9+La7Uzy9xLGTo4K8oKIp/rR4EEVwHtiFsAiK57r0xiYWD+2tBefHPLlwEA39zyLC5Ufbwy0R6g4a3+jBYUZXlZGKBHgjcxGryNCK14YO4lendwFkjBecbYgJO+nSVdV3knQzS4cwqzhH6xPt+C7yGRvmXpINPrUPMAKllRH2cuzZ7NjUdf29HjVNaSSNlLYIphQfOAmu8Vzn/dsD6GmjeRuKeXM+dkcn7+7Wj5lXhbbnYOd5WexGR9F354xkRNj/u3Y6i8Cx8GY5iLjNRs5/NNNhUZqNwTl3cXnozL//5zRpJ/6KFP4vKVT030+O+9d3dc/supi3GZeuU36RQN8/PQ6Qgv9U+U62HMcgQmN7z0mXz9JvlaA0CJRCTTqPhGSCO9uemu5Km1vJf8fORS5y7I7KWC8VwPQ/MsrTWTk2DkSLR+yBiAWDiuoKF9r6N9PtZUtmE8+AARWvDgY1X5DjTnzXBoClU2XS7na855emu0tqIoS8ld5SfZz4YquwAAn8wdYesoSjcwUT0VD8wRWpgOPsGa8rbl7pYTGq2tKMqy8cefHMH/+PRo4mc/OP06ji5I6YoiZKJ6CpPBSawv78C9A9/E+vIOTAcfYzr4ZLm75kTPvjl7TNQhlbLzuYqpQ+SRuij1YLK8RGUZZ9nZOgBjiiHxek2ToTmpW5CC0tVUgOIj+TdxTa1XaxrJspQ3Eho7HWGRLpvL/ibl2kk2A4mI1HgzseRaKrmS6YBi3vhl95O3h/X+nQCAFmnjE5h0kLNNE5VdC4xMTo0bOCmVTkesxx1x+fEhcy4f+2dzuPPlEC+8dBS3FQbx/G99HQCw7dXj+O5Lx/D9U8fw3MZh7Ohv/xZ/N7053nc8/1FiH6z7k/V6Tjae4a+LZJlacq3Jrv3kPlg+5NZ0XfJzrUkk7hZjAkO91enz0fKeDmn0O01t2W6nkFtF2jbnox5OI4mQsfh0nTbjpgho36/MvoGgfgnl4hb4hT6MNz+BX+hDMdyA6eBj1MJpRJG5hyXPWMl0YJZVLhw9OzgritL7PP+1xwAAL/zgpfb/f+vr+O5Lx/DCX7+GF7/xBLac0fXVigNRhHJxCyrFzdbmOL2lKGakO9DBWVGUZeX5rz0GbNuMF37wEr73hz9BvdHEi994As//8uP4H99f7t4pvUSltIX9bGGAppnUupmeHZw5OY3KP3YqtuRoSkqlOBiXV82vEwWABokSnq2NxGVLxpHI1xEjoRC4VJV5kgqNSllWlGVSmwLJWpTejWlTAuvhy6XKJN+pWjfSKh8F6yopSeonS58SM5uIGs9YMvhSRHFTmS05leR6Yt85XHw6Ln9xQ3vfHAlePjZm6h7Asbg81jDXOpvKlJwDak4y502ZctMcrHnWyOPf+aVH8b0/fBn1RhPFnI/f/vyDCM9OY7pp7sMQZuqAmsqAuS7ATK1wqRvt50Ly7+9bz5pkmbVlGe1IZHNKskztM884W8oWmI2Q65GuiuB+O3p+FuRuGinP3nuuEjGFmyJgrjsasR4y3uHWd+Luf6afIrOWJYjW1oAwRVGWnd/5kwOoN0IUCznUwxa+d+Cd5e6SoiwrPfvmrCjKyuB3D7+DFw+9gxf/5TC+8y/24MX/9H/x4v63AABrcU/K3oqyMlkRgzOVHegC8wZmk6pbrC2bSNJN+c/F5cHWhrg845t2LpRNNOtklZoxUClIYHghkEFoKjQaIUnNOJLmTzolX7Oys8SDWCBZcRGaEqMSO2qSNMOaRHB+2lzkrhs0OhpRsgGELBSFGmRQuZZEmFop9TxSxxy3mDdGHg9Gj8Tlf7Pd+JMP/0Zbbvb6zZTJa79vejl6/PNx+UjOXOv1kEutSKVRE6F7tWHsEg9eMbL5hv+3HT++cgA/GnkHv3nXl/HVj76IV39nFvfOPIdvbl6HF/fvx4PltXig0s6SNRVdNkdijCRk3tcGTganlEhqy7XlO+Ny2TcrCRqRkVYnSXIFOi0jMR6xPd1NmXrJc/cWm3aVXHiWP33TT9zO++K3z3m9mTzFIfLrd1w9Am6akvHot8ymuHSagrSVXH1RnzvEihicFUVx43+eO4zDP67j+a9/cdFnPzx7FGHUAjC85P1oIcJzG4fxr++y+/GNzbsBAO9OLLXbmqJ0Jzo4E0aqbwHwsXHeCYlyKXgdURQB5criHRWlx/A9Dy/8qB3w9Z1/vjve/sOzR/HHnx7Bv936NLdrR/nlTcPzpcUq1zc270azpoOzcmuy4gbnkMgd1PeVUswZya8/b2SqXGMUJ4NDGMAabO3fFm9/bfLnuBT8HA+Ud6PhG4lrxjcyG5W1naUbAo3Kto0HSGQlY34Qzcsvlr8w1xfWFzg5GpE1DCBwkeaSCE0ump7Wb1kSMSdHJcuaEkmMx0365ny5bTmN9iE9oputz8h+tA+3kT8ov/jgR/P/bsPd6zbihf/2V4ge2o7n/8Ov4bv/5c/xx58ewXee2oXf/tLd+NafEY/zpilLUvpRw5g5ssLhjcqBuHzt7KNxedAzRilXo7G4fMX7OC7PNmiqSiLDCgxvJJHYFHofDs0nUgCARzzT5/Ulc75HAvN93yqb36cRmj86aGS1BG76qMX4eEvaoc/HKEw+b2lSb8R4SncsJS2XDpjzsnZ9TpGZI1HaR+5ZxtxvnWLFDc5ZuK/8DADgZHAIlVwOu1bvxjszB/FhcBAPlHfj/sozeA/vL3MvFaUzPP/tXwEAvPCf/wy/+1//D+r15vzA/PAy90xRFB2cr2NhgH57dj+Ozx5CC2E8MCvKSuP5b/8Kvvf7P0K93kSxmNeBOYUT1YPw4MVBapRTweH21FclPWe2oqSxMgZnV/9qKgUSidD32nrHA5VncTo4ghZC+MhhW+kp1FttubHpGTmtxfgpu0Y20342SZRrASZCu9Y0Rg7U+9YixYSE8yN3TSspir6UmKwQuHPGS3gSL2PaDpWFb9xzm5fB0qVSiYEJiHmILdGndo09t6M1890vXzDy8b1TU/juH/1Ne2Au5FGvN/Eff3wS/+7etqXm5SD5WuemVVqkkx4TuT1VNZHMHxbMNU19nqlkTaeL6HZ6n/CpGCnpftr0u9CVEtsis4qjVX4Thyf2YUM5h19Yb6xF/+zCUZwMDuGp/r2Yw13x9nHfeIBzsnZkmYeY399VvhZNN1GzkSg9faNEJk5qW2TW4RjFzd0/lkwtuYepfzk1KuFkbcGzzN0IKR01IUngZPVwPDC3EOJM8Er6TorSY3z3j/4GL/zBj/Hit59D9fgf4MVvP4fvnzqGH5x+fbm71rV8eWAYz6zbi8MT+/DT0fb8+U9HD+DVyX14qn8vnlw3vLwdVFYMK+PNuYOcrB7Gh8FB7KjswUN9u/H+3EG8V23fhNvLX17m3ilKZ/j9Mz/H7/3ta3jxW1/H89/6JQDA89/6JYz/5BK+f2rBtvMry9fBLubLA8MAgJdH9+GnYwcRRqEOzErHWdGDMyeV0hRjk+GFuPxq/QTGguPYUH4Y+dJ2nAwvIF/ajoFoBKeDw7jqXUXoE29gJrWa3QlBVCGRLOn2av1q8ndhohaT+uC64J5DEn0pidZk22GgafPovmyEub13avtcZLhtbCORxLn2OZMLclyfkcrZ34u2Q81JqJRsJOAPvONx+Q9OPAEA+NlEH37jzmfwzJs78Q+/YUxCGtWv44m1q/HK5RZG88Zwp9EkkiwnO1oGKqQ6Te/XMu1EDXLtEL9ma1/md+DML3gDG87khvYTZLvZt4JCXC7Mbx4eHMark+2BOefl8FDfbkzV2+1WPROhHTHR95y/t7OULbjnuOkpiVFI0rPJ1ZSDm05LTX17XR3uuZfF49pKZ8ntK2lfTUiWlggRNpQfxobKTsvOaX3lc3ENMA8gReklnly3F8/dnjwH+vja9lzqj2dV3uY4dG1/PDCHUYg3pw/gkTWa3lLpHDo4E4YqfKTqwgA9Wjtxs7qjKEoXcujafhwY34evDO7FLwwO4x+u7sffX90HADpAKx3Di6Ieyj5NKBQ2Jn8g8GWlslaOyKaFvImOpl7WNEUa5yvrurielXclsoxLlKOgPcugoyUw6BBIO6LF/XTXDL7WnMQtMaTgPbe5YxFjE0tyl7TjZmbCnbcoMlKp5xVI2Xz3nG+W85QKxgN6XWlbXN48n1TCi0y/Lnmn4/JU/XxcDhrGw51Kgfb1kv69OeMGSbSwbFomPSpbQqmwLi5v7SNuacEFnKgexIOV3XioYpzVjsz9BJeD17G5/Bjq5ifBTHAxLodWhLnbtelqcpH3jYlKpWTyBORJNDiNTqZGMZbUS0iUtTNA7x829S3rre3miS2SxK2d3WRzeqx643JiHVf0zVlRFEVIFEV4sLIbD163znlz+dH4c536UjqBDs6KoihCPte3m/1sYYA+G75xs7qjrGBuGVmbIjEJyRLlbMk1nEwskVa4NgUSUCJLEFFIj5knUiqV4aiRhEQ25xb3+0zUJyf/8cYA6SYUbN9E51BShzsWY3gg+I6WTMxI3HnfmH3kctTwZP7oJBUjXdVgeTIzUfPuMqybzE9x/c2zyMWV4qa4vKponjt039m6kYXpNBjn4y7zAE+uT39Pu475Ldb13ROXb8+ZWJr+yMj1k95EXL4Qmoj+qcBMZ3ASd9xfyZSco0mUs/+2a/scGXy/KY3GSGodCfrmrCiKsoK5XH0DnudjU/kLiz67ErzVHviLhYQ9leVEHcIURVFWMJ7n43LwBq4Eb1nbrwRv4XLwxpJkVFKyszLenB3TMlqmDy0u0leQPow5Fifdst7W3HEZKc7VyCOpvU5J3DkS/VnMm1ScbLo7xkiCwkqWnM+vZSQhkTvTpUPenCQ9VSW/PTmi2zXCXCIH02uEnvMGaX8hnSH3cOamT+j5KOSNTNq0org/Ww69/riu3sQygw5mWos5l1xa0Wr9SlwOGsYYiIPzXJf0h5ty49KBWmYjZOprVd7I7ztyu3AKq3AqOIRNubVxtr3LwRu4v/ws7is/g+MwA/esb2TZpGcZf986PpckU3JZnlmcsQrzm1hTEFlWzXSIlTE4K4qiKCxJ2fYWBmalO1E9Q1EU5RbgvvIzcTIfHzkdmLuclfHm7Bj112Kl4xuXskVyN5FNJH6zlhc3TYsm8NNN7CPF1ZtWcC5DRs6nEcASXOfAJBHLERM1K6HFyJScTH3d3qn7yiRdThLlvLsNtj+1kZsXpNKIa5tKvtxqARHc9+ZMVtKjqTsl/1P47+UWDe4qZVttMukPad9yMNHa9LfNeaW4XIQxIVngVGBn2ztRPYR7ym2DlZaX7AGe2HfGVMY6x1weAUkaWkqWdJOCvAbctS/qA1enQ6yMwVlRFEVhORUcxqngEHb27cGOvt14b+4g3p1rZ9tbGKCV7kIHZ0VRlBXMwsB8X/lZ7Jg3UdnRtxvVMMSZ2uF2pcriN21leeldE5L8huQPMkT3SaKmO7WgnpW1CTRCk5oBpElDXCQ4268sXrO0v4z06WroksVn2xV3A5N0ZN7dEhMSN6MSXvpOka0Z/+JyYcCUSVQ2/X1mapficr05ZeoIzElknujp54OXjiX+7m5TKJwRDsXVYERiisTBScyDqx40lYIZeJ6HLeXHkItMitGr/kWMV08gQoQoZ9Y5z9ZMdHqaX7/Iv5rCyd30OSXwr8+S18DZc9txWlNNSBRFUZRUbqt8kf1soNIexK/WT7N1lOVBo7UVRVEUpcvo3TdnToJgJA42YpCpwx6WkYnZfQURg1Z1JkLTxWyErctJSnRiI4M/rmVYwJiHSGQqrj9cZLrod+POq8Bz2dkgQ2CQYpMs79Hzafu1J/ef9ww3bSalTqXb1lbujMsDua1xeWPrNrMfOc7HlXfi8tisyXXeDOdS+8jdS1wEsP37cFHqEuMZN29tVk5l4FIbSsx1uONKrlO6GmSi+lFcrpdmEtuv1ZJT4bpMB7pK2RRLkiflUtFMp+Rzxgs+bNXiclA3KUxFhk60OxmmzdjnzhJEa+ubs6IoLGPVd3G1+l7iZ+eCn2Gq+vFN7pGi3Bro4KwoCosHD1eDd3E2OGptPxf8DGdrR+F5mrtY6Sy1xhjqjE1qrTGGWn30JvdoeehdWTtDJHaWY0WMSUAmuSOLx6yLvysTsXjD7V1fn9vOGUk4nifnVJ9IliM5KZOTIzk4L2ZONrdJl2JZsxnBtWx5MTPX6YLk7hOv+YpvJMXB1iYMljbhfLQaZ2uvos8r4IHKszhRPYSztaN4oLwbUWVLXH/cN1IqlbVdo8u5OvbfAa6mL2QrSbnIR4y7GaRwRiIUiaGKbaLD9Z+k+mTum0ZopOzJOVN2vYfsDxK2dyoq25p6yaFav4icX7JSdE7Xx1BvjKGveDsiUr/RNN+PM3RyXTHCraZZCqmco3cHZ0VRbgp3lJ/AKq+IE8FBnAxeQQshHijvxv2VZ/Ahzix395QVRqXU/oOvWr8I38tjdfkuzARnMVe/gL7i7egr3Wblz16p6OCsKEoqD1SejQdmHzncX1FfZmXpWBigZ2tnMVs7ByCKB+Zbhd4dnF1TdGUylXCM0LZ2dlv8zkm9Ii/uxE46mqYsRW5Xxl/cdV9nKVvg0czty6Xlo5K1RPrmI7TTo6y5dqgMTSO6aZ/zOeP4VCkaw54cuY5q4fSitmuRidqd8YypyIW5Y2ghhDfvy/z23D7cVX4Sc56Jmg2ZvnDnIGLlf86LWxJl7TYVY6divXH/dQ5uqoT2nzM2kay6oIjkaNd9U+qy0wLc93AwaKmUtqBavwQgAuChXNqMVsIzgH0+00h5MtVQyK+Oyw06/cJMxXHTV9azfQmsvHp3cFYU5aZwJXgbI7U3cVfpKdxVfhJng6M4W3u1/WFlzWfvrCg3SLVmBmYgQrV2KX6jvhXQwVlRFJYrwdsYCczADCD+92ztVaz1tmNteftydlFZgVRrl1CtX8Sq0l3xnPNs7SwA3DID9Irw1mYlX0fPVWszJ3dm8JLlpRLXFHzp7TvVzRKhvQQp1FwNWlxlQVk0NdO3DqUzlPlHp8vdtI7vmSjedX33xOVN+c/F5Upk5O5R7xwAYKpxMd5GZe8WWpirXYQHD/2V+xYdeSb4FEFzAsX8egBAPTSSOD33YWtu0b6Lv5PEMMTVKzv9/HHTF9z0CHe+XadcuDoS0x2KczrGDB75HTHaYL4fPZeeF6LeGEOxsAHlgonWrtYvo9G8hkJ+PTySHrPFpKrN8iwTmRypt7aiKFkYqb4FwMfGyq5Fn01UT6EWTrFvI58VgLO6vBWtQK0SlA4TRSgWNqBUsJMbLfwRiChil6utJPTOUpQVj4/R4C2MVN+xtk5UT2EyOHn9AmJFWVZKxaFFA/MCxfx6FAuDN7lHy0PvvjkzEc6sRMRJ04wMTqP78pZpgakTSuRuBs6HumMyS1LbjgYnESfh0Wd5BgMVZxMEWkfy+wv25Y7LTTW4yuAUmXc35x9N26F9S/59izkTkXq3vwuVqIyzwVGsjlbh7vJT+Dh4FZO1kxgs70SYz8XnMCRtV+tjcXm6dd4c39mnnpOp6TlAYh3eKzsZvs1k7KmpZOMW1ruZu34Zf3SJhM5F/UqOZUehM9cvc73YJiDJ5yGMgkX7dWzqkPSX+mZTuGlEdrojwzSea8pgX2AM5ErvDs6Kooi5s/wlAMDHtVfwSe0oIoQYLO/EYGUHRhonUvZWFOVmo7K2otwi3Fn+EjzkEM2vVx6s7FjuLimKwtC7b86MNCGRlCUmHpYfscRQgUmLaMnXHfKhtiQUIjEvSLGu6RQ5nKPgHb8flfDYtHmOkjW3L4U7P5JUkuyxGJ9gSTpAiK41QUQ3qV8n3soT+bZMOFJ9Z35g9hEhxKXqa1hT3oagfs20Rs5B2AoS+2KnKWSuSwJnMCIxaPHYezu5jtWKaEVEekQ/RXYtJEvZVh3H+9LZkMRR6pVNB+UXt2dVYORfxyhvyTNcMj3G1ef66fq8s89xByLZr6N3B2dFUcSMVN/BaPAWNpYfwaby5+P1y4qidCc6OCvKCmdhYB4qfwGbyp8HAGwqfx5VTGA6+Bj53Frkc/3L3EtFUSi9a0JCFqe7er1SuMjEcnGA1CnE5aBhJMBmaGQ/SqfSh7GyXJpftqOftijdpaNHuHOkpKv0JYnQz2LuQpCZX5C+OUZly47lJvUW82vJ9iY8eKiUtiBHruXZ2ggazXE0W1X4fuUGv0c67lJ9+r4S73MKJ7m7Gt5IovUlUfauU08ioxImcttuKPmes9JQMsRTdJJVJFlkXkdjI+6ekaSqZNtxNB6hqAmJoigiPstIpJAfQKszf8MoitJBNFpbURRFUbqMFfHm7Jp+kZNl+kpGKh8obI3LIRpxmXoPz9QumzrUbCCL7EuImIjHVJnVVYK2Dpp+HNaUQdK+wJDEJXJ0EYKUeJIIai+D5M56fTMGGXxaweRoUIl3d4NEa09VyfRLwjln5eIMUjaF769rtCu9RtIjsTmjGkqOGAxRrOh7q9H068KEy9NHAAAgAElEQVS6V0RpLknzju9LknSMknuRjWZPaFNigmPVd11x4ej1z62+Yc9NFuORpUipy6BvztfRzoZyOfGzieopzNYu3OQeKYqiKLcaOjhfj+chqF/CeNV2TVrwIfZuBcd1RVEUZVlZEbK2SGpg5A7fN6eglFuLUmUtZrwSxoMT8JHHYGUHpqsfYTI4iaHyLuRKJoq7kF8Vl8O6kbVdo4Q56dnysOYkuoTvLvH5lsjdbMSiICKai0zlIiJZmZpr03WNgUCOZGVcj9ZJj9zm0g1ykrG74UW6LO8L+rnwu3Dyr0Q+l6VZTEYSuR0x0yxcBDWbVpREI0tSMbaQPI0TtdKPyyHx3JakVCzkyHOnVTNtWnJ6ukwtuv8S7hvJvcqZDTmncWTalPyGWbCua4/Z3qFVORwrY3DuMKvLW1HyVuNq8C6uBe8jQgtD5V0YquzCtda55e6eoiiKssJRWZthsLJj3uawBQ8+hhJy4SqKoijKUrAi3pyzeC5bKSAjIxFdrv58vp6HCC2cr76KteXtqLdMFGytMZnYpt25G482tJpxiLqWpLhzlmQ6FKXIfldBRC8YSYkzaLC8uwVTDVQ6bKGeWMd5ykIQiS+LiuYi5NOjgdljOURrc+05e0Sz3/XGTUi4/nBmLbR+szVH6icbVdjXFxK3c376XNQ/679O6hRI2s/Vpc1xeVXerCppkmfWTMMEss7VRhPbd/ahTqvKmaBQJKYiXArIDGllWVz9yOmuGZ7zrqyIwbnTzNbOY652HmvL27G2vB1TwRlMBWcAAPnCumXunaIoirLS0cH5Oq4fmAHE/04FZ1Bp3YZKactydlFRFEVZ4ayIwTlHJKWcX4rLjXA2LnPe1NQ8ZK4+hkZzFoX8evj51ZhpXmnv22oAfgmlwhCaYTWWs1kJ0lXikES2OkjfnGGIyMtakkLNOmi6DO9shEK7w9RnDQYymZAkR4C6eivbbSZLma4r8vgIWSbKmWzP5/riMjXaiaIQgD09Q81LKBJJWZKi0TXto6v8L/O+FphQcPsy55im13T1euck2lLBJCO5PfdwXL4LRuJukD6cKZ6JyxeJ73+taX7fLFOASftK7nM7Up6R2AVR5Evi48+sVBClj8xgVCRhRQzOnaRYGGQ/KxWGrMFcURTlZnC5+gY8z8em8hcWfXY6eAVR1ILfx3uoK72HRmsriqJ0OZ7n43LwBq4Eb1nbTwev4HRwyFnRUbqfnn1zZs0DIuKDTdOgtWgdYhhCPqDyT705HZe5yEqR3MEhkFnYVJgppiVUkrHMLri3flevWQZ6nrgUfa2IMd9wlNw5OBlOFPXJpuJLN5vgjit5aGbxreYit0skcPG2vsfi8n3R/aaOlwMAfFQwlrSf1l+Ly3O1K+RAyf3lzFTYaGTGYEQiU3N12PtTIIlLDFUoztHDzuk1zXep5I2K9/n8k1gd9eF0cBiXCv14dM0evDF9AKeDQ9i1ahgPr9qND+smVeFYfk1crjXGyQHc+pl4fwhkYdEzhcF+rt64Xz+Hq+ER7Q9d0dGplLQcPTs4K4qi3EpsL38ZAPDz6X14Y/ogWgjjgVlZeagWoiiK0iNsL38ZPnJoIYSPnA7MK5iefXPm5KUW8b6lkdt5vxKXqRjBRQ9SySJkU9KlR/S5plR09bxOkmhsuSWfWFfivcvCyVqMHzX9HVphujyfJV0b57ntHK3NGFKIZNMMxgkSmVXiHz1QuScuP57fGZe/NGT2Lfvtk/X2+LZ425w3FZcvkKmdZmjMOnivcTNtwknckvSOHJw0zfpsc/cYs51rRyKDc0iuBe45Qk2RZrx29PW54GfxwNxCiGNT+3Bf+RkAwJxnIu2p5zbfOe4+ZnzxF1aDcCsNmGcH9SkXparl0lBKnk2OKT1dDU+WWsqm9OzgrCiKG8dn92MSOfzi0J5Fn70+dQAttIA8v1pBWV7OBT/D2dpR7Ozbgx19u/He3EG8O3cAAOIBWlk56OCsKLcIHnz8ZHQfAFgD9OtTB3Bseh8eX7N3ubqmpLAwMN9VehI7+tpS9o6+3ai3WjgZHAIA5Ctbl7OLSofp2cGZSg107TFNpyYxNrA/EERNs969ZFdJSjWCsyctIUkOdpXSO0WOMRuQSGxcn+00gfX0+oJoam67JDqei8SWRIm7+lCzUzcCM4tV3oa4vKmSm/93L3aFLfzphX0YKIb4V3c8jT+58AqOTR/CL6zfi+HBYfxo9FK835WcmQqixyySSGAqWVPTnwaRwTkpkJO7JRI3F6HtGqFvR+Imt2mbx7iZXIiuBeYena2Z6OsAEdaU70FYXo13w0/NrpXNWI8dGMNV+E1iPEKMZSwE00Ss5J4i6dK69FlgXS9+IS43mvR6MWXWqMQxsl5CpuejmpAoitIpfv22tvz5pxcO4i8uvoJGFMYDs9K9rK1sZz8brDwEABhvfnKTeqPcDDRaW1FuMX79tmeQ93JoRCEKXk4HZkXpQnr2zZmLjm62qnGZSitU+pZEVvMHJlGicIv649pxTalmkSbFuO7nnMbR0CT+wj5jjsF5nEtMCzjJmo2aZdJHWu07Sp+uRhUimdVRTpPUr0Umcneybo57sVrAyyMH0IzCeIB+eWQ/vtQ/DACoelSONvsN9Jk3t43evXG5hLI5jnc1Ll+pvReXq3Wznabi5KaIKK5TBK4R16KUm7SfUfL2jsmapJ06MUW6OvdhXJ7MnTXVSX0rlwDzvOM86SXTO0kmJPRZQOXrgbJZLbDaM0GGPnJxeSpvZPvpxsW4TK8XawpSkKrUSt0ZCayWs6wM6ZC0ztGzg7OiKO68PHIAL43sxy9vHMY/3bwbP7pyEH99pR0ktjBAK4qy/OjgrCi3CG/PHMCbM+2B+Wsb9wCI8Nym3bgceDg62R6g4d+5rH1UVh6j1ePw4GFDZeeiz6aCM4iiCH6+L2HPW5ueHZwtSYFZFE8jRqlkQaUPzhuYlyDdUpilGYZ8ZjsZJJdUXCVzgaQE5lz6jKGHtSv3ezpG1rPpIwXRtFbzjjKVq/yaJaqY205lvIm6ieh9F+0lNpcb09i1ahhrsRuHRyIU/PaJLuIRbC3VcDGoIiidjvejMuXt3o64vKtsUhb2F01fzs+aCPHXS2aKY4xcCwH1eaYIDDGs6s6e1Z2ZjkhLoSitw8HtS01gaFnyfJFgeUZz034LJiRMJHt/2fxhty0y18uEX8e7c/ux2R/EvfMWpABwtPo+poIz2Fx+FBEZnGmkecRdF0wfqZzvPNXo6KG/FFI2pWcHZ0VR3Li98jgeKG5M/Gxr+UkAwIno6M3sknILsHPeYvTduf1oRi08WHkWJ6qHcDl4A5vLj2JT+Qu4HJ1c5l52Hzo4K4rizJvT++F7HnavX2xc8sHcIYxHlzBQeWAZeqZ0I3SAPll9BS2E8cCsJNOzgzMfXZgeic2lM2TbYY7LyW92xKDAi1WyuN5hwTs9viV70pSRrhHijuYLlsTNHZeLoG0ly/zsuZF4BDPR2hyusqZou4Ohw2chkcFpuscPsT8uX8IdcTmHtiHEXGvMbCM+6P0FU3e7b964H1rn42LTx9+O7cMdfZifvwZKuQKOjO/H+9UDuKv0FO5otaO6J3Pn432p8URIovtdI58lqSTpds5IhPqBu0rQrEFOh6YsXPyur4eVuzmjJe7+S4FeLxVvIC73kyj+NYV220+tG8b7c4dib/C7S88ACfclOwUheTYRJLIzZ4TTDT7bPTs4K4qyfHx1wzAA4KWRdiDZ1zbuwZHx/Tg8sQ/PrNsLRPpGpNi8MX3AStpxPngNd5SfWO5udS06OCuKckN8dcMwSn6El0b24yejh9CMQjyzbi+eHhjGkWsTy909pYt4Y/oAXp/ehy+sGsau1XvwzswBvDW7HwB0gGbo3cFZEhEt8NZmDQkYD2XORMNj5BERtB0/2bzDIkVKDrnF98z5sKQdpPedi4Jko9EF0d0SXKVsSTsieVGAyJBAYOoSOUpr9gfJ56FaGzVlYvBQzLWjsddXjKkIjbKttIwPcrloQuiJpwm+umEYL88PzDnk8PTAMADAJ3kl2TSOjEmMRI6UeJxLPPQ5P23uWFYzguvF9TriEPWB+vszZiNcm2yUM70eF8rkfFPTpyAy6UYnIzNl8cn4EbxXPYAdlT24s/g0xusN3Fl8GhfCazgXHEXgzaGZN+YkNO2vq7mLaPUF9zwXtHkzU0aqfaeiKIv4NHgVHwVHEj/bd3U//n6sLWf/dPQAwihEzsshRIgj4/tvYi+VXiBChB2VPXhoPpvWAkOVXRgq70KUNPGs9PCbs6IoS4YHD2dqhwEA95Sfjre/M3MQb8/ux1cG97YH6av78LWhvfjHQ3vwFxcP4PBEe9D28ciy9FvpPnb0Lc4fvsBQZRcA4FLjPbbOrUrvDs4Sgwy6nRhbWLIv80ebJfk4+kGL4CRxQUQ1G9E5/91dPV85OV+UTlGy0F8QGS7ywWXOvR1xmf77WJHbgmjzLL7cXH2J7Chp02pf4ENOyefaEbWDJIJ7U76dcnXT6q+gP1fC8bn96MvlcVffHrw5fQBvz+7H42v3YqoBHJvahyf79+LeyjDOzAB3FJ7Fzr4Ihyf2Yag8jo3zD95mw0if7L0k+K5s1DwTjSxJK+maqtLqj+P5pthTQMx0TYeuC3bahzN44VaJJECfV9N14499vmTSjc6ExrQm8Izn+3jrXFyu1s2KAev5nOU3ccyV4DNpLmmOhmZI0nIS7/NOTV9QendwVhRlSXl4fm3q8bn9eG9+Ccyjq4fxxbV7cGxyHx5fuxdPXOfHvbCe9Urr2s3urqKsKHRwVhSF5eFVu+OB2UcOj6xpS5SP9y82H1lg56rdiDS3sNLD1Bpj8OChWBhc9Fm9eQ2IIiCDXaqEFTE4u/pd2zszJhdMOxKpxNksA8nSChdJaEWPtxbLwa7tsTDTAtyxOKneVe52NWJpMTIYF1nJScqidHoCn3AOifSVxevbVU5fuI4anjl/QRia/SLgg6oZmFsI8drkAdxTMv7IV1vG5/mab6LCLzc/iMv15jRp0+2cibysrYhier3QYvJUkM88Al39ty0Ezx3u+eK6YoDWz/nG+EOyqsTVt35hmiBingvU+IbKv+P5j+MyTd1Lrwv2WcetmuGiy0l/nNJg4nqjGiCoX4LvF1EpbI03B/URNJrXUCpsBGBWM1BDnU6xIgZnRVE6zwfVQ/igegCfq+zBI6v34PjsQRyf249Gq4UHKs8ud/cUZcmoFNvz5EH9Enwvh1WlOzBbO49aYwSlwkaUixsR1JkkLh1iRQzOkjck+heV7xiAJVpTK9iXe4tl+0Pg1lEnvcnbmYrc1v3aQTTpbwbcORZlbJG8aWdIYs+qHAJrVrqvFRDGvYW4ti+waaS4rseWvDU0mu233onChXjb2flHwpXgbYwEb2Jz+TGUSvfj4/oEVhd24c5SgBPBQUxgFpvLj+IyTMKCWfLmRG06m9SmUxBE5WqFagf4IbFOlmxlvPLA2HcyAYfsd+/QNS56lgna4a7B1GcJOWYjNL9/PZxOqm0jUBVdM1RZzQuC3K4PCFwYoOdq5zFXuwAgQqkwhFJhA6Koxa7Z7xQrYnBWFKXDRC1sLj+GzeVHrc13lJ9Aw2sginRtqrLyqRQ3I6hfRntZj4dSYeimHVsHZ0VRFrGp8kicGON6rh+wFWWlUiUDMxCh1hi9aQN0zw7OaWt9ry9TOPmHkz5Yaz4qraUEaQF8kIZlmSkJUCNYgVoLbbpmnBL00dmakyDK0sRJmUnf7zP6QAN8WImYkfCc1ypy6+vpsRxtFyV0KuvRgvQ4Uf003hYUjQWjT+rS7ENhWIvL1YaZd6NSJncPcIisMLnfjZGv2fX4gmtcYtNIg4C4THdswCHDkth9CrI2iaboEtqWBM45e0NIbIsFiIJSaX0YC9Fmq4paYwz1xti8lD2EWmMUtcYoWq0mCvkB9wBbR3p2cFYURVGUpWBhYC4WNsRvyqXCEFqtJhph+w9Sj0THLwU6OCuKoigKJYrmB+YN1uZCvp2zOkIEZnVpx/CiHo3sKBY2J24XZQ1hpGOPWfOWzxkrOhoxGLaMvNdk1rlJIrG5tXaRQDZ1QWTN6RhlLbG/FOEa4UwRyPiukqXr93KOQhasN82ytlly3IU++14xsS4r1RK4aZBOZdTi9u3UeuOlxjXSmyKyn2QPnD5Fd6PZ07hrJJPNseSZwiBa6SHoAz03hdyquNyKGnGZrtPmrtNGcyxxuyudj/9WFEVRFCUTOjgriqIoSpfRs3POmez1GPs5j4lOpbK21UyDyjuChfsCaYU1EmDkHcvYJEE2l0S4upqpSPrlLJ9xZhCc/NuhRf/OcnenTFE4e1AuUnkJpNuFNrnf3zXiOouhh+Tci2xguWjtDKYvXB8k95bEclTynHK9L10jlVmSzhW9RrjfTdJfWp1buSF4TrFTKIJzwE1r1knGKdGzZglMSPTNWVEURVG6DB2cFUVRFKXL6FlZm8OKPOUyS0kW0TPyS6vVSNzuGlntGiHNSTSJsrklC9PjpJuBcHBZqXhpj8phyRGUWaQsu3Pp54+VxGhGowzGIBKy+EpzdSQmF5x8vHCvcGYUWUxZuPtQYjDiKs9LJGXWeERiDGL1zTHbU4cy40nyAdjnwZx/iuiZKLjXkz8XyN3WDm4rDegUXsRMX3D7slMf1rXPdSL9d5OsbHBF35wVRVEUpcvQwVlRFEVRuoyelbWzJKWX1TFJ52n6O0qzVU1tM0vUsiSKMy0isSWRUh0jylkEkb4Sw4CISfvnGq3L1iFkSW5vRXo6+iZLTGBcjyVJSZko6TEyL5sSUXKeHH2HJZHV7L3EpYMkuJ5jSUS3RQYTDasZTqIVRG5zsrPkvElSKi70jZt2YmVhQRQ5u5JEkv7Wdbori3ESZxi0BCY3+uasKIqiKF2GDs6KoiiK0mX0rKwtSRln75AenWz7ZhsZL4Qpc97XEtmMk25Ffs20z9wC/JSUkWwENYdISqMSEf0guY+cFy8XIcpKigK5UxL17Spli8gQVZ4latnZe3q+fZHUKEhBmNT2Z/VFtJ1cUyI5WkAWWV6UrpO5DyTPJrshgVkKJzFzWRlcfasTfvcsKygk+7J1XFNJOnrus33g6HDug+vRN2dFURRF6TJ0cFYURVGULqNnZW1JxKLEeEIicVpyN4laZaU1gRycIyYBIU03KYgqtj9IOBYj27CR2xmiF7kIStq+z8mmEp9liVFBlmhzR59wV0nX2ePYMX2kxNTDjsBenB6SjXxmju8q27rK7a7GIFlSTGbpj8TwyNUfmzvPfIS047XvGFWe2L6r/z4lw3SUq1e2ZHWHZZwiyWvQqRS5AvTNWVEURVG6DB2cFUVRFKXL8KKIXTre1RQKGxO3i4wKGGmF84bNIrlyfaNIJDd7BwfZNMMie1dJlotk56K1KVRSYj23Jb8twTVaWxIZLrmOssjXXUUGUwZRO64mEZL2Bdd7Jv9wzsvaNWJckqrUdRWHZHUFc51KvLvT2uiU/JvFYIprx3VayDWqnP4OjcaISzdZ9M1ZURRFUboMHZwVRVEUpcvoXVk7v8H8h0ndxRltcFIMTUlGEflTu8omTH0ripvxM3aRdyQSVKaIYkf5TNRPV5ODTsmvHBm8ktl2KI7SrbMBT0r/nQ09SHv0evX95CmLZmhWIzgbTDC4ptakkdWWT7ir6YujsYWrZM1GbjumJHSermH2tbqWdh936LkgqcOZGTk/72haTp9eI8mpQSVjTb1xObHPruibs6IoiqJ0GTo4K4qiKEqX0bOydrGwOXF7zqfmHslpCymiaENHOMmlU1GL3ML5BVmGTa0mwDl6PYNUnkn6dky/mamO1Qk3KdZVfs2StpLrW6rM6vid8rm+uFzMr4nLpfzauBxGjbhca0zG5UZo0q9yaUUpIq90QqemnbLg+vuIIsAzGJtYSIxHJP1Palrw7HDFOTJ8qREcV6O1FUVRFGWFooOzoiiKonQZPeutTSWOnMdE2TH1WSmrQ9G0XB8K+dVxudGcictslCDtAvXTZaSmxH0l8iaT3lGSEtOCS2VJq9xg1Lm4PhNNmWasIG7H0aiE87gWGVgIUgZaSPyR6fb58+lJJras81GIy6X8WswG5wDPw7ri1nh7iLasPRV8hGY4i0pp8TRUnUu5x113S236Ye3gJvXb0dTpUy6sh7ZEyuYQSK7WtYzkKTc/wX+d9o27DzM9OyQrayxPbMEKkyzR91x115UtGdA3Z0VRsuF5mKudx2Rw2to8FXyE6eAjeB6XXFhRFI6efXNWFKU7WFW6AwAwGZwCAPSX740H5jXle5AjQWOKosjo2WhtzoSEhZEarSqCyGOrvqtZBoGVRzochdgpMxCJJO7MEnjxuvqpSzy6M6WPW4rtWUg6n4Jj0t+fRmj3Fc19WKuPYio4A8ADEGFN+W6sKW9D0TPTOT5ycXkmNFGtU8G5uEynDiQR3RRXP/WWwOjHOWra8bdyvreytJ/F9z0hJa3oe0u87JcgTwGHaDWNK6T/Gq2tKEpXsba8HQsDM+BhTXnb8nZIUXoYHZwVRekI7bfm9sAMRJgOPlneDilKD7Oi55w5OUok70qkoAypB1lJRxJlmWLAIJGLnKOvJSkXHQ1J2HPsKHFJ+m/V5+R6GrcUpcvj7LG4qNwlNrywuiNIhZdYR2CO0SIGI/WwveogqI+g1hhBX/F29JVuQ6MxgcngFOqNSQwWtuO28mMAgEJkIoEn66cRIcKGyk40itV4+0xw8ca/nyByl0Yps0Y/3G/lGLkt6Y8oetw6QIb7w3EKIzFam4vvk/iFk31dpxdFqxcE54bLuUDJ+eW4HLaMN3ynphok6JuzoiiZuH5gBtpBYf3l+1ALr+FicAwXg9etfc4Hr+Fq8C48aCS3oiSxot+cFUW5GUQoFTbGA/MC/eV7AQBhYxYXg2MAgK2lp3A+eA3nakcxWN6JwcqOm95bRekFejdau7Ax+YMORQBzqRs5JDKivcONRye6RDm6pmiTyOcd88HuEKIpBVo/S+Q5k2K0U1GfIqmP6Q9XPy3aWORZTc1UaMpIcg5yfikuD5bvi8ubW3fjQnAM52s/g4ccIoTYWnoaq/vujeuMhCfj8lTVRG43W3PJ/XFMbSk6T0z6SOfI7Sx0Kv1plihq5vvG10aWZ5fr6ggJGVa4OHt3C1aAaMpIRVF6htvLj8ODjwghPOSwtfzkcndJUboaHZwVRVlyLgTHEKEVvzl/Ghxd7i4pSlfTs3POomhNRz9aTlKk5EkUX5NG8XF9EHg0SyTgG5WGRR7XpC8hqS/ylOaiKTlpTLBdBBMBKooYdTRi4KJXXQ0yRDKrq8zOReM7TFZJpgI4b/coTP4ejcjI0WdqBzBWO44N5YexqfIIRqrv4NPgCAa8axioPNiu3zLR2vRa43yeJT7bkjoSX3OrDhfFz+zr7stNdhXI6c7PO24Fg8tzx1FGZu95JhbQZ02fmHvY1WBIcv4kv6HrM8WRnh2cFUXpfqaDTzAdfIwN5YexobITALCxsgsAMBq8BQDxAK0oikEHZ0VRlowoiqyBeYGNlV1oIkCEnoxHVZQlp3ejtam3NoGLKmWjaQUL8e32qRwskIIE8qhIPpaQFH3rKCPnrcX3RraV9Fcy1SDy7pZEJkvMADpVhyNLtK5jJLG1682KKs7gm76qtCkuV/KDcTnvmYjuWmsqLs/ULsVlmk5V0nfndJAE51SyWVaDSLzemXuC67OLeciifbm+MSy07+z/vQT++87pYLNEhjvmWWg0x9LbFKABYYqiKIrSZejgrCiKoihdRu/K2owJicisI8MCc08QGegqTVuGJ0wEODW84KIWY+9bgVS3FOnarPYzRF9nMiGgLIWhg+u+kjYFUZ8iyZUjpZ9LIe1Sb+J8rmKqk/rN0ERoWysflsCnmJJFBuf2dW1TZISzBMYmziskHPrgnJoyC46R1bRvVBIX+WY7HldlbUVRFEVZoejgrCiKoihdRu8upeKiFBmJiErHVso4ZkF6PmdkOYrvFeJy2KqR4954RDKbAtIxIjFNSmLTMjpKuxIZlPMmXxLP7SwRmq77OkqN1m9IzwMzmcRFYruaq0gMdeK6jlI2dx3TMpULuakaDmdpX4Ik3aCoP+nmMSLzkAxpIp29qmk/s6TgTLgGnY2KrIOmG8N0Kp0mZ7QkolOR547om7OiKIqidBk6OCuKoihKl9G7sjYnLzDbqbRmpfpj5GJqwJFjIqVpijyqlFDZPBLIuOx2R5OOpGjtpM+vr0MjazkJ2tV8xUqzyflgS0wZBAYmzpH4VqeZPgikW1aCps1LIqG5/ki2EyT9sXfwF9d19f92PD43BdUpz3X22pesSeFkfM5bW1Lf6pzgnDDXF3eu7IbSry/uHqL3pYuBjTVFKJgekfyeoum3DsnL3Dm2Vscw97/dUOffc/XNWVEURVG6DB2cFUVRFKXL6F1ZmyCKWOR8trnUcHRX5BK3t6KGOSw5rmt6RRZXOWjhuJL9SF9CMNHU1vdI9+3NJDvTrjH7dspUxrkPBDoFIEkZaUllNP0hd41kkfGySPoJ25zNOly9r+m9x0Wvc/ekwEeaa6fFTN3cTD/1TGliJWkaBQYp1vTejcrmjmkTXf3CKVx/OXxmpYR1jfv0OiLXCDPdKXrGdQh9c1YURVGULkMHZ0VRFEXpMnrXW1uQMtJVBvWtfam8l+6z3WSMFrj6Iv9tQaoyq/qCNCSQQ7NExHLp2kTnnpIlvaNjpLez5EvJYnIiqMNK3679dzQNietkOR8dOgcWrsYqkvqdSunZqTShlAznUJQmUjCN5zJtJvkd2D66ponl2u/Q9cXWz+Brrt7aiqIoirJC0cFZURRFUbqM3o3Wdoz05fa15Z90KdvyxG5ROZKRen0aMWjqc97TXNo9aqJC5aAkcxCRYYkl4dBiupzDSfKSc89GUEqQ+NTSOJEAAAGOSURBVDtzfVgKGYyjQ17Cli83NXvgJqIkUnbKfixLkcpQYqziGE3dqZSXrFTO3CuuUm+WlRtWM4KobOd7RWDM49JHro5kJYn1rPOZaUfmGet6jq370BPU0WhtRVEURbm10MFZURRFUbqMno3WVhRFUZSVir45K4qiKEqXoYOzoiiKonQZOjgriqIoSpehg7OiKIqidBk6OCuKoihKl6GDs6IoiqJ0GTo4K4qiKEqXoYOzoiiKonQZOjgriqIoSpehg7OiKIqidBk6OCuKoihKl6GDs6IoiqJ0GTo4K4qiKEqXoYOzoiiKonQZOjgriqIoSpehg7OiKIqidBk6OCuKoihKl6GDs6IoiqJ0GTo4K4qiKEqXoYOzoiiKonQZOjgriqIoSpehg7OiKIqidBk6OCuKoihKl6GDs6IoiqJ0GTo4K4qiKEqXoYOzoiiKonQZOjgriqIoSpehg7OiKIqidBk6OCuKoihKl6GDs6IoiqJ0GTo4K4qiKEqXoYOzoiiKonQZOjgriqIoSpfx/wFp7J+vZLd2QAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Gs.plot_diffraction_vectors(unique_vectors=Gs,\n",
+    "                            distance_threshold=distance_threshold,\n",
+    "                            xlim=reciprocal_radius,\n",
+    "                            ylim=reciprocal_radius,\n",
+    "                            min_samples=min_samples,\n",
+    "                            image_to_plot_on=s_rb.max(),\n",
+    "                            image_cmap='magma',\n",
+    "                            plot_label_colors=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Optionally save and load the unique peaks\n",
+    "\n",
+    "`np.save('peaks.npy', Gs.data)\n",
+    "Gs = np.load('peaks.npy', allow_pickle=True)\n",
+    "Gs = pxm.DiffractionVectors(Gs)\n",
+    "Gs.axes_manager.set_signal_dimension(0)`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate VDF images for all unique peaks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyxem.generators.vdf_generator import VDFGenerator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radius=scale*2\n",
+    "\n",
+    "vdfgen = VDFGenerator(s_rb, Gs)\n",
+    "VDFs = vdfgen.get_vector_vdf_images(radius=radius)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "VDFs.plot(cmap='magma', scalebar=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1(b) Watershed segmentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First find adequate parameters by looking at watershed segmentation of a single VDF image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyxem.utils.segment_utils import separate_watershed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_distance = 5.5\n",
+    "min_size = 10\n",
+    "max_size = None\n",
+    "max_number_of_grains = np.inf\n",
+    "marker_radius = 2\n",
+    "exclude_border = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "i = 27\n",
+    "sep_i = separate_watershed(\n",
+    "    VDFs.inav[i].data, min_distance=min_distance, min_size=min_size,\n",
+    "    max_size=max_size, max_number_of_grains=max_number_of_grains,\n",
+    "    exclude_border=exclude_border, marker_radius=marker_radius,\n",
+    "    threshold=True, plot_on=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perform segmentation on all the VDF images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "206635404c3a4fb7b9f036b7f42f5948",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=53), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Anaconda\\envs\\pyxem_tinabe_VDF2\\lib\\site-packages\\skimage\\filters\\thresholding.py:596: RuntimeWarning: divide by zero encountered in log\n",
+      "  (np.log(mean_back) - np.log(mean_fore)))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "169  segments were found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "segs = VDFs.get_vdf_segments(min_distance=min_distance,\n",
+    "                                  min_size=min_size,\n",
+    "                                  max_size = max_size,\n",
+    "                                  max_number_of_grains = max_number_of_grains,\n",
+    "                                  exclude_border=exclude_border,\n",
+    "                                  marker_radius=marker_radius,\n",
+    "                                  threshold=True)\n",
+    "print(np.shape(segs.segments)[0],' segments were found.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segs.segments.plot(cmap='magma_r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1(c) Correlation of the VDF image segments"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate normalised cross-correlations between the VDF image segments to identify those that are related to the same crystal. If the correlation value exceeds *corr_threshold* for certain segments, those segments are summed. These segments are discarded if the number of these segments are below *vector_threshold*, as this number corresponds to the number of detected diffraction peaks associated with the single crystal. The *vector_threshold* criteria is included to avoid including segment images resulting from noise or incorrect segmentation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corr_threshold=0.7\n",
+    "vector_threshold=5\n",
+    "segment_threshold=4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|                                                                                          | 0/169 [00:01<?, ?it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7  correlated segments were found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "corrsegs = segs.correlate_vdf_segments(\n",
+    "    corr_threshold=corr_threshold, vector_threshold=vector_threshold,\n",
+    "    segment_threshold=segment_threshold)\n",
+    "print(np.shape(corrsegs.segments)[0],' correlated segments were found.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Simulate virtual diffraction patterns for each summed segment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sigma = scale*1.5\n",
+    "\n",
+    "virtual_sig = corrsegs.get_virtual_electron_diffraction(\n",
+    "    calibration=scale, shape=(int(radius_px*2), int(radius_px*2)), sigma=sigma)\n",
+    "virtual_sig.set_diffraction_calibration(scale)\n",
+    "#hs.plot.plot_signals([corrsegs.segments, virtual_sig], cmap='magma_r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the final results from the VDF image-based segmentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.axes._subplots.AxesSubplot at 0x1c61b6ff198>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61df82ba8>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61d76a518>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61dc51da0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61e2b46d8>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61daf6fd0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61d830908>]"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hs.plot.plot_images(corrsegs.segments, cmap='magma_r', axes_decor='off',\n",
+    "                    per_row=np.shape(corrsegs.segments)[0],\n",
+    "                    suptitle='', scalebar=False, scalebar_color='white',\n",
+    "                    colorbar=False,\n",
+    "                    padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                             'left': 0.05, 'right':0.78})\n",
+    "hs.plot.plot_images(virtual_sig, cmap='magma_r', axes_decor='off',\n",
+    "                    per_row=np.shape(corrsegs.segments)[0],\n",
+    "                    suptitle='', scalebar=False, scalebar_color='white',\n",
+    "                    colorbar=False,\n",
+    "                    padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                             'left': 0.05, 'right': 0.78})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_rb = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2 Non-negative matrix factorisation-based segmentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the NMF-based segmentation, the required pre-processing, binning and alignment, were done at the start of the notebook. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create a signal mask for the direct beam\n",
+    "Create a signal mask so that the region in the centre of each PED pattern, including the direct beam, can be excluded in the machine learning. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm = pxm.Diffraction2D(s.inav[0,0])\n",
+    "signal_mask = sm.get_direct_beam_mask(radius=10)\n",
+    "signal_mask.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Perform single value decomposition (SVD)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s.change_dtype('float32')\n",
+    "s.decomposition(algorithm='svd',\n",
+    "                normalize_poissonian_noise=True,\n",
+    "                centre='variables',\n",
+    "                signal_mask=signal_mask.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "200ff8d14448415b81262c1aa3292632",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(Label(value='Decomposition component index', layout=Layout(width='15%')), IntSli…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "s.plot_decomposition_results()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Investigate the scree plot and use it as a guide to determine the number of components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_comp=11\n",
+    "\n",
+    "ax = s.plot_explained_variance_ratio(\n",
+    "    n=200, threshold=num_comp, hline=True, xaxis_labeling='ordinal',\n",
+    "    signal_fmt={'color':'k', 'marker':'.'}, \n",
+    "    noise_fmt={'color':'gray', 'marker':'.'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### NMF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s.decomposition(normalize_poissonian_noise=True,\n",
+    "                algorithm='nmf',\n",
+    "                output_dimension=num_comp,\n",
+    "                centre = 'variables',\n",
+    "                signal_mask=signal_mask.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_nmf = s.get_decomposition_model(components=np.arange(num_comp))\n",
+    "#s_nmf.plot_decomposition_results()\n",
+    "factors = s_nmf.get_decomposition_factors()\n",
+    "loadings = s_nmf.get_decomposition_loadings()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the NMF results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Anaconda\\envs\\pyxem_tinabe_VDF2\\lib\\site-packages\\matplotlib\\pyplot.py:514: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).\n",
+      "  max_open_warning, RuntimeWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.axes._subplots.AxesSubplot at 0x1c61e1c3ef0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61d51d400>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61df75f28>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61b662438>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c679c7c630>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c67959cef0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c67f5687f0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79c3b80f0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79e1429b0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79e185278>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79e1c0b38>]"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hs.plot.plot_images(loadings, cmap='magma_r', axes_decor='off', per_row=11,\n",
+    "             suptitle='', scalebar=False, scalebar_color='white', colorbar=False,\n",
+    "             padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                      'left': 0.05, 'right':0.78})\n",
+    "hs.plot.plot_images(factors, cmap='magma_r', axes_decor='off', per_row=11,\n",
+    "             suptitle='', scalebar=False, scalebar_color='white', colorbar=False,\n",
+    "             padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                      'left': 0.05, 'right':0.78})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Discard the components related to background (\\#0) and to the carbon film (\\#4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hyperspy.signals import Signal2D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "factors = Signal2D(np.delete(factors.data, [0, 4], axis = 0))\n",
+    "loadings = Signal2D(np.delete(loadings.data, [0, 4], axis = 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.axes._subplots.AxesSubplot at 0x1c79eebe0f0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79eefebe0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79ef3f550>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79ef7edd8>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79efc1710>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79f004048>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79f040940>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79f082278>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79f0c0ba8>]"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hs.plot.plot_images(factors, cmap='magma_r', axes_decor='off',\n",
+    "                    per_row=9, suptitle='', scalebar=False,\n",
+    "                    scalebar_color='white', colorbar=False,\n",
+    "                    padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                             'left': 0.05, 'right':0.78})\n",
+    "\n",
+    "hs.plot.plot_images(loadings, cmap='magma_r', axes_decor='off',\n",
+    "                    per_row=9, suptitle='', scalebar=False,\n",
+    "                    scalebar_color='white', colorbar=False,\n",
+    "                    padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                             'left': 0.05, 'right':0.78})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2(b) Correlation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NMF often leads to splitting of some crystals into several components. Therefore the correlation between loadings and between component patterns are calculated, and if both the correlation values for loadings and factors exceed threshold values, those loadings and factors are summed. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Investigate the normalised cross-correlations\n",
+    "Calculate the matrix of normalised cross-correlation for both the loadings and patterns first, to find suitable correlation threshold values. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Anaconda\\envs\\pyxem_tinabe_VDF2\\lib\\site-packages\\matplotlib\\pyplot.py:514: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).\n",
+      "  max_open_warning, RuntimeWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x1c79f1844e0>"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyxem.utils.segment_utils import norm_cross_corr\n",
+    "\n",
+    "num_comp = np.shape(loadings.data)[0]\n",
+    "\n",
+    "corr_list_loadings = np.zeros((num_comp, num_comp))\n",
+    "for i in np.arange(num_comp):\n",
+    "    corr_list_loadings[i] = list(map(\n",
+    "        lambda x: norm_cross_corr(x, template=loadings.data[i]), loadings.data))\n",
+    "\n",
+    "corr_list_factors = np.zeros((num_comp, num_comp))\n",
+    "for i in np.arange(num_comp):\n",
+    "    corr_list_factors[i] = list(map(\n",
+    "        lambda x: norm_cross_corr(x, template=factors.data[i]), factors.data))\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.imshow(corr_list_factors, cmap='cool', vmin=corr_list_factors.min(), vmax=1.0)\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.imshow(corr_list_loadings, cmap='cool', vmin=corr_list_loadings.min(), vmax=1.0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyxem.signals.segments import LearningSegment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = LearningSegment(factors=factors, loadings=loadings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corr_th_factors = 0.45\n",
+    "corr_th_loadings = 0.3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perform correlation and summation of the factors and loadings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6fef66d210f3438781e421bb6ab1339c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=9), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3cfdaae7a8cf4482b1eb8ed8c91676ae",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=9), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "learn_corr = learn.correlate_learning_segments(\n",
+    "    corr_th_factors=corr_th_factors,\n",
+    "    corr_th_loadings=corr_th_loadings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the NMF reuslts after correlation and summation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Anaconda\\envs\\pyxem_tinabe_VDF2\\lib\\site-packages\\matplotlib\\pyplot.py:514: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).\n",
+      "  max_open_warning, RuntimeWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.axes._subplots.AxesSubplot at 0x1c7a49abfd0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a49f3ba8>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a4a34518>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a4a72da0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a4aba6d8>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a4af5fd0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a4b37908>]"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hs.plot.plot_images(learn_corr.loadings, cmap='magma_r', axes_decor='off',\n",
+    "                    per_row=7, suptitle='', scalebar=False,\n",
+    "                    scalebar_color='white', colorbar=False,\n",
+    "                    padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                             'left': 0.05, 'right':0.78})\n",
+    "hs.plot.plot_images(learn_corr.factors, cmap='magma_r', axes_decor='off',\n",
+    "                    per_row=7, suptitle='', scalebar=False,\n",
+    "                    scalebar_color='white', colorbar=False,\n",
+    "                    padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                             'left': 0.05, 'right':0.78})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2(c) Watershed segmentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since one single loading map can contain several crystals, watershed segmentation is performed on the correlated loadings. \n",
+    "\n",
+    "First investigate how the parameters influence the segmentation on\n",
+    "one single loading map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyxem.utils.segment_utils import separate_watershed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_distance = 10\n",
+    "min_size = 50\n",
+    "max_size = None\n",
+    "max_number_of_grains = np.inf\n",
+    "marker_radius = 2\n",
+    "exclude_border = 1\n",
+    "threshold = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Anaconda\\envs\\pyxem_tinabe_VDF2\\lib\\site-packages\\matplotlib\\pyplot.py:514: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).\n",
+      "  max_open_warning, RuntimeWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "i =1\n",
+    "sep_i = separate_watershed(\n",
+    "    learn_corr.loadings.data[i], min_distance=min_distance,\n",
+    "    min_size=min_size, max_size=max_size, \n",
+    "    max_number_of_grains=max_number_of_grains,\n",
+    "    exclude_border=exclude_border, \n",
+    "    marker_radius=marker_radius, threshold=True, plot_on=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set a threshold for the minimum intensity value that a loading segment must contain in order to be kept. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_intensity_threshold = 10000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "814a41be172d4c339fbb4d3ed6e74262",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=7), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "learn_corr_seg = learn_corr.separate_learning_segments(\n",
+    "    min_intensity_threshold=min_intensity_threshold,\n",
+    "    min_distance = min_distance, min_size = min_size,\n",
+    "    max_size = max_size, \n",
+    "    max_number_of_grains = max_number_of_grains,\n",
+    "    exclude_border = exclude_border,\n",
+    "    marker_radius = marker_radius, threshold = True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the final results from the NMF-based segmentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Anaconda\\envs\\pyxem_tinabe_VDF2\\lib\\site-packages\\matplotlib\\pyplot.py:514: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).\n",
+      "  max_open_warning, RuntimeWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.axes._subplots.AxesSubplot at 0x1c7a51947f0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a51d9320>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a5219c50>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a525b518>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a505aef0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c7a49bf278>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c79f1a0dd8>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61e1f0d68>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61e03ce48>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x1c61b71f128>]"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hs.plot.plot_images(learn_corr_seg.loadings, \n",
+    "                    cmap='magma_r', axes_decor='off',\n",
+    "                    per_row=10, suptitle='', scalebar=False,\n",
+    "                    scalebar_color='white', colorbar=False,\n",
+    "                    padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                             'left': 0.05, 'right':0.78})\n",
+    "\n",
+    "hs.plot.plot_images(learn_corr_seg.factors, \n",
+    "                    cmap='magma_r', axes_decor='off',\n",
+    "                    per_row=10, suptitle='', scalebar=False,\n",
+    "                    scalebar_color='white', colorbar=False,\n",
+    "                    padding={'top': 0.95, 'bottom': 0.05,\n",
+    "                             'left': 0.05, 'right':0.78})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
A notebook was added that demonstrates nanocrystal segmentation on a SPED dataset obtained from partly overlapping MgO cubes. Two methods for segmentation are demonstrated based on i) virtual dark field (VDF) imaging and ii) non-negative matrix factorisation (NMF). Watershed segmentation is performed on individual VDF images and loading maps to separate out single crystals. Correlation and summation of VDF image segments and loading maps is also performed. The necessary pre-processing is also demonstrated. 