### PR TITLE
Update some of the notebooks from pxm.load to hs.load

### DIFF
--- a/01 GaAs Nanowire - Data Inspection - Preprocessing - Unsupervised Machine Learning.ipynb
+++ b/01 GaAs Nanowire - Data Inspection - Preprocessing - Unsupervised Machine Learning.ipynb
@@ -60,6 +60,7 @@
    "outputs": [],
    "source": [
     "%matplotlib tk\n",
+    "import hyperspy.api as hs\n",
     "import pyxem as pxm\n",
     "import numpy as np"
    ]
@@ -84,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dp = pxm.load('./data/01/twinned_nanowire.hdf5')"
+    "dp = hs.load('./data/01/twinned_nanowire.hdf5')"
    ]
   },
   {
@@ -960,7 +961,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.1+"
   },
   "widgets": {
    "state": {

--- a/02 GaAs Nanowire - Phase Mapping - Orientation Mapping.ipynb
+++ b/02 GaAs Nanowire - Phase Mapping - Orientation Mapping.ipynb
@@ -60,6 +60,7 @@
     "import numpy as np\n",
     "import diffpy\n",
     "\n",
+    "import hyperspy.api as hs\n",
     "import pyxem as pxm\n",
     "\n",
     "accelarating_voltage = 200  # kV\n",
@@ -87,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dp = pxm.load('./data/02/polymorphic_nanowire.hdf5')\n",
+    "dp = hs.load('./data/02/polymorphic_nanowire.hdf5')\n",
     "dp"
    ]
   },
@@ -949,7 +950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.9.1+"
   }
  },
  "nbformat": 4,

--- a/03 Reference Standards - Dimension Calibrations - Rotation Calibrations.ipynb
+++ b/03 Reference Standards - Dimension Calibrations - Rotation Calibrations.ipynb
@@ -53,6 +53,7 @@
    "source": [
     "%matplotlib tk\n",
     "import numpy as np\n",
+    "import hyperspy.api as hs\n",
     "import pyxem as pxm\n",
     "\n",
     "from pyxem.libraries.calibration_library import CalibrationDataLibrary\n",
@@ -88,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "au_dpeg = pxm.load('./data/03/au_xgrating_20cm.tif')"
+    "au_dpeg = hs.load('./data/03/au_xgrating_20cm.tif')"
    ]
   },
   {
@@ -104,7 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "au_im = pxm.load('./data/03/au_xgrating_100kX.hspy')"
+    "au_im = hs.load('./data/03/au_xgrating_100kX.hspy')"
    ]
   },
   {
@@ -120,7 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "moo3_dpeg = pxm.load('./data/03/moo3_20cm.tif')"
+    "moo3_dpeg = hs.load('./data/03/moo3_20cm.tif')"
    ]
   },
   {
@@ -136,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "moo3_im = pxm.load('./data/03/moo3_100kX.tif')"
+    "moo3_im = hs.load('./data/03/moo3_100kX.tif')"
    ]
   },
   {
@@ -549,7 +550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.1+"
   }
  },
  "nbformat": 4,

--- a/06 Nanocrystal segmentation in SPED data - Demonstration on partly overlapping MgO cubes.ipynb
+++ b/06 Nanocrystal segmentation in SPED data - Demonstration on partly overlapping MgO cubes.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dp = pxm.load('./data/06/mgo_nanoparticles.hdf5')"
+    "dp = hs.load('./data/06/mgo_nanoparticles.hdf5')"
    ]
   },
   {
@@ -1089,7 +1089,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.1+"
   }
  },
  "nbformat": 4,

--- a/08 Pair Distribution Function Analysis.ipynb
+++ b/08 Pair Distribution Function Analysis.ipynb
@@ -72,6 +72,7 @@
    "outputs": [],
    "source": [
     "%matplotlib qt\n",
+    "import hyperspy.api as hs\n",
     "import pyxem as pxm\n",
     "import numpy as np"
    ]
@@ -96,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rp = pxm.load('./data/08/amorphousSiO2.hspy')"
+    "rp = hs.load('./data/08/amorphousSiO2.hspy')"
    ]
   },
   {
@@ -467,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.1+"
   }
  },
  "nbformat": 4,

--- a/09 Angular Correlations of Amorphous Materials.ipynb
+++ b/09 Angular Correlations of Amorphous Materials.ipynb
@@ -56,6 +56,7 @@
    "outputs": [],
    "source": [
     "%matplotlib qt\n",
+    "import hyperspy.api as hs\n",
     "import pyxem as pxm"
    ]
   },
@@ -65,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = pxm.load(\"./data/09/PdNiP_test.hspy\")"
+    "data = hs.load(\"./data/09/PdNiP_test.hspy\")"
    ]
   },
   {
@@ -226,9 +227,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.1+"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/10 STEM DPC Analysis of Magnetic Sample.ipynb
+++ b/10 STEM DPC Analysis of Magnetic Sample.ipynb
@@ -11,7 +11,7 @@
     "The data we'll be looking at there is from the paper **Strain Anisotropy and Magnetic Domains in Embedded Nanomagnets**, and is STEM data recorded on a Merlin fast pixelated electron detector system, where the objective lens has been turned off.\n",
     "This allows for magnetic information to be extracted, by carefully mapping the beam shifts.\n",
     "\n",
-    "More documentation about pyXem is found at http://pyxem.org\n",
+    "More documentation about pyXem is found at https://pyxem.github.io/pyxem-website/\n",
     "\n",
     "Journal article:\n",
     "* **Strain Anisotropy and Magnetic Domains in Embedded Nanomagnets**\n",
@@ -61,6 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import hyperspy.api as hs\n",
     "import pyxem as pxm"
    ]
   },
@@ -93,9 +94,9 @@
     "    os.mkdir('datasets')\n",
     "except:\n",
     "    pass\n",
-    "if not os.path.exists('datasets/005_stripe3.emd'):\n",
+    "if not os.path.exists('datasets/fe60al40_stripe_pattern.hspy'):\n",
     "    import urllib.request\n",
-    "    urllib.request.urlretrieve('https://zenodo.org/record/3466591/files/005_stripe3.hdf5', 'datasets/005_stripe3.emd')"
+    "    urllib.request.urlretrieve('https://zenodo.org/record/4312960/files/fe60al40_stripe_pattern.hspy', 'datasets/fe60al40_stripe_pattern.hspy')"
    ]
   },
   {
@@ -118,10 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = pxm.load(\"datasets/005_stripe3.emd\", dataset_name='/fpd_expt/fpd_data', lazy=True)\n",
-    "s = s.transpose(signal_axes=(0, 1))\n",
-    "s._lazy = True\n",
-    "s.set_signal_type('diffraction')"
+    "s = hs.load(\"datasets/fe60al40_stripe_pattern.hspy\", lazy=True)"
    ]
   },
   {
@@ -130,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = s.inav[:, 300:500]  # Run this cell to reduce the size of the signal, which will make most of the processing much faster"
+    "s = s.inav[0:200, :]  # Run this cell to reduce the size of the signal, which will make most of the processing much faster"
    ]
   },
   {
@@ -391,7 +389,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_threshold_mask = s_subset.threshold_and_mask(threshold=2., mask=(16, 16, 16))"
+    "s_threshold_mask = s_subset.threshold_and_mask(threshold=3., mask=(16, 16, 16))"
    ]
   },
   {
@@ -416,7 +414,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_crop_com_threshold = s_crop.center_of_mass(threshold=2., mask=(16, 16, 16))"
+    "s_crop_com_threshold = s_crop.center_of_mass(threshold=3., mask=(16, 16, 16), lazy_result=False)"
    ]
   },
   {
@@ -425,7 +423,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s_crop_com_threshold.compute()"
+    "s_crop_com_threshold.plot()"
    ]
   },
   {
@@ -592,7 +590,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.1+"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request changes `pxm.load` to `hs.load` for all(?) notebooks.

I have not run through all of the notebooks, only "10 STEM DPC...".